### PR TITLE
Redis connection will only be attempted 5 times.

### DIFF
--- a/lib/app.js
+++ b/lib/app.js
@@ -54,7 +54,7 @@ function logout() {
 
 function login(hostname, port, callback) {
   console.log('connecting... ', hostname, port);
-  redisConnection = redis.createClient(port, hostname);
+  redisConnection = redis.createClient(port, hostname, {"max_attempts":5});
   redisConnection.on("error", function (err) {
     console.error("Redis error", err.stack);
     if (callback) {


### PR DESCRIPTION
Currently, node redis will retry failed connections indefinitely, with increasing delays. It supports a max_attempts argument to prevent this. I added it such that it will give up after 5 attempts.
