### PR TITLE
Added support for unix-socket connections

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,6 +16,7 @@ $ redis-commander --help
 Options:
   --redis-port                    The port to find redis on.        [string]  [default: 6379]
   --redis-host                    The host to find redis on.        [string]
+  --redis-socket                  The unix-socket to find redis on. [string]
   --redis-password                The redis password.               [string]
   --redis-db                      The redis database.               [string]
   --http-auth-username, --http-u  The http authorisation username.  [string]

--- a/bin/redis-commander.js
+++ b/bin/redis-commander.js
@@ -16,6 +16,10 @@ var args = optimist
     string: true,
     describe: 'The host to find redis on.'
   })
+  .options('redis-socket', {
+    string: true,
+    describe: 'The unix-socket to find redis on.'
+  })
   .options('redis-password', {
     string: true,
     describe: 'The redis password.'
@@ -64,6 +68,8 @@ if (args['redis-host']) {
       }
     });
   }
+} else if(args['redis-socket']) {
+  redisConnection = redis.createClient(args['redis-socket']);
 } else {
   redisConnection = redis.createClient();
 }


### PR DESCRIPTION
This adds support for connections to redis via a unix-socket as described in #83.
To connect via a unix-socket use the `--redis-socket`-option.
