### PR TITLE
Add init.d script for Debian. Requires dpkg >= 1.16.5.

### DIFF
--- a/dist/debian/init.d/redis-commander
+++ b/dist/debian/init.d/redis-commander
@@ -4,8 +4,8 @@
 #
 ### BEGIN INIT INFO
 # Provides:          redis-commander
-# Required-Start:    $local_fs $remote_fs $network $syslog
-# Required-Stop:     $local_fs $remote_fs $network $syslog
+# Required-Start:    $local_fs $remote_fs $network
+# Required-Stop:     $local_fs $remote_fs $network
 # Default-Start:     2 3 4 5
 # Default-Stop:      0 1 6
 # Short-Description: start Redis Commander (redis-commander)
@@ -17,6 +17,7 @@ RUN_MODE="daemons"
 # Reads config file (will override defaults above)
 #[ -r /etc/default/redis-commander ] && . /etc/default/redis-commander
 
+PATH=/usr/local/sbin:/usr/local/bin:/sbin:/bin:/usr/sbin:/usr/bin
 NAME="redis-commander"
 USER="redis-commander"
 GROUP="nodejs"


### PR DESCRIPTION
This init.d script has configurable parameters. The way I configured
it requires 3 things:
1. A system user called nodejs which has its own group and homedir.
2. A system user called redis-commander which belongs to the nodejs
   group and uses the nodejs homedir.
3. The nodejs homedir MUST have g+w permission so redis-commander
   have permision to write as well.

Below is a step-by-step to get it up and running:

```
# useradd --system -m -s /bin/false nodejs
# useradd --system -d /home/nodejs -G nodejs -s /bin/false \
  redis-commander
# chmod g+w /home/nodejs/
# cp dist/debian/init.d/redis-commander /etc/init.d/
# chmod +x /etc/init.d/redis-commander
# update-rc.d redis-commander defaults
# service redis-commander start
```

Please, let me know if you find any problem.
