### PR TITLE
Update dependencies to fix TypeError in node versions > 0.11.3.

### DIFF
--- a/lib/app.js
+++ b/lib/app.js
@@ -6,7 +6,7 @@ var fs = require('fs');
 var path = require('path');
 var redis = require('redis');
 var express = require('express');
-var browserify = require('browserify');
+var browserify = require('browserify-middleware');
 var myUtils = require('./util');
 
 var viewsPath = path.join(__dirname, '../web/views');
@@ -38,7 +38,7 @@ module.exports = function (httpServerOptions, _redisConnections, nosave) {
   } else {
      app.saveConfig = function (config, callback) { callback(null) };
   }
-  
+
   app.login = login;
   app.logout = logout;
   app.layoutFilename = path.join(__dirname, '../web/views/layout.ejs');
@@ -50,8 +50,8 @@ module.exports = function (httpServerOptions, _redisConnections, nosave) {
   app.use(express.query());
   app.use(express.cookieParser());
   app.use(express.session({ secret: "rediscommander" }));
-  app.use(browserify(path.join(__dirname, 'browserifyEntry.js')));
   app.use(addConnectionsToRequest);
+  app.get('/browserify.js', browserify(['cmdparser','readline-browserify']));
   app.use(app.router);
   app.use(express.static(staticPath));
   require('./routes')(app);

--- a/lib/browserifyEntry.js
+++ b/lib/browserifyEntry.js
@@ -1,2 +1,0 @@
-exports.readline = require('readline');
-exports.readline = require('cmdparser');

--- a/package.json
+++ b/package.json
@@ -18,17 +18,18 @@
     "redis-node"
   ],
   "dependencies": {
-    "optimist": "~0.3.4",
     "async": "~0.1.22",
+    "browserify": "^4.1.11",
+    "browserify-middleware": "^3.0.0",
+    "cmdparser": "0.0.3",
     "ejs": "~0.8",
-    "redis": "~0.7.2",
-    "sf": "~0.1.3",
     "express": "2.x.x",
     "inflection": "~1.2.0",
-    "browserify": "~1.12.2",
+    "node-redis-dump": "~0.2.0",
+    "optimist": "~0.3.4",
     "readline-browserify": "0.0.4",
-    "cmdparser": "0.0.3",
-    "node-redis-dump": "~0.2.0"
+    "redis": "~0.7.2",
+    "sf": "~0.1.3"
   },
   "devDependencies": {},
   "optionalDependencies": {},

--- a/web/static/scripts/redisCommander.js
+++ b/web/static/scripts/redisCommander.js
@@ -565,7 +565,7 @@ function loadCommandLine () {
     hideCommandLineOutput();
   });
 
-  var readline = require("readline");
+  var readline = require("readline-browserify");
   var output = document.getElementById('commandLineOutput');
   var rl = readline.createInterface({
     elementId: 'commandLine',


### PR DESCRIPTION
Updating browserify to the latest version fixes the error noted in #115.  browserify-middleware is added to replace the middleware functionality removed from later versions of browserify.
