### PR TITLE
Send Redis Password on Default Connection

### DIFF
--- a/bin/redis-commander.js
+++ b/bin/redis-commander.js
@@ -85,7 +85,7 @@ myUtils.getConfig(function (err, config) {
       console.log(err);
       process.exit();
     }
-    if (args['redis-host'] || args['redis-port'] || args['redis-socket']) {
+    if (args['redis-host'] || args['redis-port'] || args['redis-socket'] || args['redis-password']) {
       var db = parseInt(args['redis-db']);
       if (db == null || isNaN(db)) {
         db = 0


### PR DESCRIPTION
Passing a "redis-password" argument does not send the password unless either a Redis host, port, or socket is also specified.  This update will cause the password to be sent to Redis even if no other options are passed to the application.