### PR TITLE
gh-pages: change pixel offset from -82px to -40px.

### DIFF
--- a/index.html
+++ b/index.html
@@ -206,7 +206,7 @@
           <h1>Install and Run</h1>
 
           <div class="highlight"><pre><span class="nv">$ </span>npm install -g redis-commander
-          <span class="nv" style="margin-left:-82px">$ </span>redis-commander</pre></div>
+          <span class="nv" style="margin-left:-40px">$ </span>redis-commander</pre></div>
         </section>
         <footer>
           Redis-Commander is maintained by <a href="https://github.com/joeferner">Joe Ferner</a><br>


### PR DESCRIPTION
Of course this could just be my browser, but `$ redis-commander` was over offset on my screen. I'm running `Google Chrome 37.0.2062.94 on 3.17.6-1-ARCH`.

I'm sure that there's a better way of lining these up w/o a pixel offset but I think that this should fix it in the mean time.

### What it was rendering...
![bad](https://cloud.githubusercontent.com/assets/4251257/5734851/4f0a4f0a-9b71-11e4-8ff5-e03febabca06.png)

### What it's rendering now...
![good](https://cloud.githubusercontent.com/assets/4251257/5734890/b8eaa0c8-9b71-11e4-81a3-989babcb7402.png)