### PR TITLE
Add "Label" to each connection

### DIFF
--- a/bin/redis-commander.js
+++ b/bin/redis-commander.js
@@ -91,6 +91,7 @@ myUtils.getConfig(function (err, config) {
         db = 0
       }
       newDefault = {
+        "label": args['redis-label'] || "local",
         "host": args['redis-host'] || "localhost",
         "port": args['redis-port'] || args['redis-socket'] || "6379",
         "password": args['redis-password'] || "",
@@ -98,7 +99,9 @@ myUtils.getConfig(function (err, config) {
       };
 
       if (!myUtils.containsConnection(config.default_connections, newDefault)) {
-        redisConnections.push(redis.createClient(newDefault.port, newDefault.host));
+        var client = redis.createClient(newDefault.port, newDefault.host);
+        client.label = newDefault.label;
+        redisConnections.push(client);
         if (args['redis-password']) {
           redisConnections.getLast().auth(args['redis-password'], function (err) {
             if (err) {
@@ -131,7 +134,9 @@ myUtils.getConfig(function (err, config) {
 function startDefaultConnections (connections, callback) {
   if (connections) {
     connections.forEach(function (connection) {
-      redisConnections.push(redis.createClient(connection.port, connection.host));
+      var client = redis.createClient(connection.port, connection.host);
+      client.label = connection.label;
+      redisConnections.push(client);
       if (connection.password) {
         redisConnections.getLast().auth(connection.password, function (err) {
           if (err) {
@@ -165,7 +170,7 @@ function connectToDB (redisConnection, db) {
   });
 }
 
-function startWebApp () {     
+function startWebApp () {
   httpServerOptions = {webPort: args.port, webAddress: args.address, username: args["http-auth-username"], password: args["http-auth-password"]};
   console.log("No Save: " + args["nosave"]);
   app(httpServerOptions, redisConnections, args["nosave"]);

--- a/lib/app.js
+++ b/lib/app.js
@@ -89,9 +89,11 @@ function logout (hostname, port, db, callback) {
   }
 }
 
-function login (hostname, port, password, dbIndex, callback) {
+function login (label, hostname, port, password, dbIndex, callback) {
   console.log('connecting... ', hostname, port);
-  redisConnections.push(redis.createClient(port, hostname));
+  var client = redis.createClient(port, hostname);
+  client.label = label;
+  redisConnections.push(client);
   redisConnections.getLast().on("error", function (err) {
     console.error("Redis error", err.stack);
   });

--- a/lib/routes/apiv1.js
+++ b/lib/routes/apiv1.js
@@ -84,6 +84,7 @@ function getServerInfo (redisConnection, callback) {
         };
       });
     var connectionInfo = {
+      label: redisConnection.label,
       host: redisConnection.host,
       port: redisConnection.port,
       db: redisConnection.selected_db,

--- a/lib/routes/home.js
+++ b/lib/routes/home.js
@@ -43,7 +43,7 @@ function postConfig (req, res) {
 }
 
 function postLogin (req, res, next) {
-  req.app.login(req.body.hostname, req.body.port, req.body.password, req.body.dbIndex, function (err) {
+  req.app.login(req.body.label, req.body.hostname, req.body.port, req.body.password, req.body.dbIndex, function (err) {
     if (err) {
       req.flash('error', 'Invalid login: ' + err);
     }
@@ -60,6 +60,7 @@ function postLogin (req, res, next) {
       }
 
       var newConnection = {};
+      newConnection['label'] = req.body.label;
       newConnection['host'] = req.body.hostname;
       newConnection['port'] = req.body.port;
       newConnection['password'] = req.body.password;
@@ -127,16 +128,16 @@ function removeConnectionFromDefaults (connections, connectionIds, callback) {
   connections.forEach(function (connection, index) {
     /**
      * Here is a bug here.
-     * 
+     *
      * When I disconnect an instance, there is always an error message in console like this:
      * "Could not remove localhost:6379:1 from default connections."
-     * 
+     *
      * So I run into the code and locate the bug here. As I output connection in console:
      * "console.log(connection);"
      * its output is just like this:
      * "{ host: 'localhost', port: '6379', password: '', dbIndex: '2' }"
      *
-     * There is no such a 'selected_db' property in connection. 
+     * There is no such a 'selected_db' property in connection.
      * I modified the code below to fix this bug.
      */
     if (notRemoved && connection.host == hostname && connection.port == port && connection.dbIndex == db) {

--- a/web/static/scripts/redisCommander.js
+++ b/web/static/scripts/redisCommander.js
@@ -16,11 +16,12 @@ function loadTree () {
         var json_dataData = [];
 
         data.forEach(function (instance, index) {
+          var label = instance.label;
           var host = instance.host;
           var port = instance.port;
           var db = instance.db;
           json_dataData.push({
-            data: host + ":" + port + ":" + db,
+            data: label + " (" + host + ":" + port + ":" + db + ")",
             state: "closed",
             attr: {
               id: host + ":" + port + ":" + db,

--- a/web/views/home/home.ejs
+++ b/web/views/home/home.ejs
@@ -36,12 +36,12 @@
             value='<%=connection.host%>:<%=connection.port%>:<%=connection.selected_db%>'
             class="btn btn-primary active"
             onclick="setConnection('<%=connection.host%>:<%=connection.port%>:<%=connection.selected_db%>');">
-      <%=connection.host + ':' + connection.port + ':' + connection.selected_db%>
+      <%=connection.label + ' (' + connection.host + ':' + connection.port + ':' + connection.selected_db + ')'%>
     </button>
     <% } else { %>
     <button type="button" class="btn btn-primary"
             onclick="setConnection('<%=connection.host%>:<%=connection.port%>:<%=connection.selected_db%>');">
-      <%=connection.host + ':' + connection.port + ':' + connection.selected_db%>
+      <%=connection.label + ' (' + connection.host + ':' + connection.port + ':' + connection.selected_db + ')'%>
     </button>
     <% }}); %>
   </div>
@@ -71,6 +71,8 @@
   <div class="modal-body">
     <div class="container" id="addServerContainer">
       <form action="login" method="POST" id="addServerForm">
+        <label>Name</label>
+        <input type="text" name="label" id="label" value="">
         <label>Hostname</label>
         <input type="text" name="hostname" id="hostname" value="localhost">
         <label>Port or Unix Socket Path</label>


### PR DESCRIPTION
This adds a label field to each connection and renders that on the dashboard. It helps a great deal with identifying instances in the main list, especially if URLs are long or if multiple databases are used on the same redis instance.

Fixes issue #143 