### PR TITLE
fixes #144 cwd bug

### DIFF
--- a/lib/app.js
+++ b/lib/app.js
@@ -9,6 +9,8 @@ var express = require('express');
 var browserify = require('browserify-middleware');
 var myUtils = require('./util');
 
+process.chdir( path.join(__dirname, '..') );    // fix the cwd
+
 var viewsPath = path.join(__dirname, '../web/views');
 var staticPath = path.join(__dirname, '../web/static');
 var redisConnections = [];

--- a/package.json
+++ b/package.json
@@ -39,5 +39,6 @@
   },
   "bin": {
     "redis-commander": "./bin/redis-commander.js"
-  }
+  },
+  "preferGlobal": true
 }


### PR DESCRIPTION
The script lib/app.js now sets node's current working directory to the root of the project/repo instead of just inheriting the current tty's cwd so all relative static web assets get loaded properly, especially when this package is installed globally.