### PR TITLE
Add a cli arg to clear the config file

### DIFF
--- a/bin/redis-commander.js
+++ b/bin/redis-commander.js
@@ -59,11 +59,25 @@ var args = optimist
     boolean: true,
     describe: 'Do not save new connections to config.'
   })
+  .options('clear-config', {
+     alias: 'cc',
+    boolean: false,
+    describe: 'clear configuration file'
+  })
   .argv;
 
 if (args.help) {
   optimist.showHelp();
   return process.exit(-1);
+}
+
+
+if(args['clear-config']) {
+  myUtils.deleteConfig(function(err) {
+    if (err) {
+    console.log("Failed to delete existing config file.");
+    }
+  });
 }
 
 myUtils.getConfig(function (err, config) {

--- a/lib/util.js
+++ b/lib/util.js
@@ -155,6 +155,16 @@ exports.saveConfig = function (config, callback) {
   });
 };
 
+exports.deleteConfig = function (callback) {
+  fs.unlink(getConfigPath(), function (err) {
+    if (err) {
+      callback(err);
+    } else {
+      callback(null);
+    }
+  });
+};
+
 exports.containsConnection = function (connectionList, object) {
   var contains = false;
   connectionList.forEach(function (element) {


### PR DESCRIPTION
Simply adds an option to delete the config file at startup.
Quite useful when you have transient redis instances.