### PR TITLE
Switched from a fixed dropdown list to a numeric input type when selecting the Redis Database

### DIFF
--- a/web/views/home/home.ejs
+++ b/web/views/home/home.ejs
@@ -80,24 +80,7 @@
         <label>Password</label>
         <input type="password" name="password" id="password" value="">
         <label>Database Index</label>
-        <select name="dbIndex" id="dbIndex">
-          <option value="0" selected="selected">0</option>
-          <option value="1">1</option>
-          <option value="2">2</option>
-          <option value="3">3</option>
-          <option value="4">4</option>
-          <option value="5">5</option>
-          <option value="6">6</option>
-          <option value="7">7</option>
-          <option value="8">8</option>
-          <option value="9">9</option>
-          <option value="10">10</option>
-          <option value="11">11</option>
-          <option value="12">12</option>
-          <option value="13">13</option>
-          <option value="14">14</option>
-          <option value="15">15</option>
-        </select>
+        <input type="number" name="dbIndex" id="dbIndex" value="0">
         <br>
       </form>
     </div>


### PR DESCRIPTION
Switched from a fixed dropdown list to a numeric input type when selecting the Redis Database

The previous setting was fixed to use databases from 0,15 , not taking into account custom redis configurations.

IMHO it looks better this way