### PR TITLE
Add an option to change root pattern for Redis keys

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,4 +23,5 @@ Options:
   --http-auth-password, --http-p  The http authorisation password.   [string]
   --port, -p                      The port to run the server on.     [string]  [default: 8081]
   --address, -a                   The address to run the server on   [string]  [default: 0.0.0.0]
+  --root-pattern, -rp             The root pattern of the redis keys [string]  [default: *]
 ```

--- a/bin/redis-commander.js
+++ b/bin/redis-commander.js
@@ -83,6 +83,12 @@ var args = optimist
     boolean: false,
     describe: 'clear configuration file'
   })
+  .options('root-pattern', {
+      alias: 'rp',
+      boolean: false,
+      describe: 'default root pattern for redis keys',
+      default: '*'
+  })
   .argv;
 
 if (args.help) {
@@ -218,5 +224,5 @@ function startWebApp () {
     args['nosave'] = false;
   }
   console.log("No Save: " + args["nosave"]);
-  app(httpServerOptions, redisConnections, args["nosave"]);
+  app(httpServerOptions, redisConnections, args["nosave"], args['root-pattern']);
 }

--- a/lib/app.js
+++ b/lib/app.js
@@ -20,7 +20,7 @@ var staticPath = path.join(__dirname, '../web/static');
 var redisConnections = [];
 redisConnections.getLast = myUtils.getLast;
 
-module.exports = function (httpServerOptions, _redisConnections, nosave) {
+module.exports = function (httpServerOptions, _redisConnections, nosave, rootPattern) {
   redisConnections = _redisConnections;
   var app = express();
   app.use(partials());
@@ -45,6 +45,7 @@ module.exports = function (httpServerOptions, _redisConnections, nosave) {
   app.login = login;
   app.logout = logout;
   app.layoutFilename = path.join(__dirname, '../web/views/layout.ejs');
+  app.rootPattern = rootPattern;
   app.set('views', viewsPath);
   app.set('view engine', 'ejs');
   app.use(httpAuth(httpServerOptions.username, httpServerOptions.password));

--- a/lib/routes/apiv1.js
+++ b/lib/routes/apiv1.js
@@ -5,8 +5,10 @@ var async = require('async');
 var inflection = require('inflection');
 var myutil = require('../util');
 var foldingCharacter = ":";
+var rootPattern;
 
 module.exports = function (app) {
+  rootPattern = app.rootPattern;
   app.get('/apiv1/server/info', getServersInfo);
   app.get('/apiv1/key/:connectionId/:key/:index?', getKeyDetails);
   app.post('/apiv1/key/:connectionId/:key', postKey);
@@ -596,7 +598,7 @@ function getKeysTree (req, res, next) {
   if (prefix) {
     search = prefix + foldingCharacter + '*';
   } else {
-    search = '*';
+    search = rootPattern;
   }
   getConnection(req.redisConnections, connectionId, function (err, redisConnection) {
     redisConnection.keys(search, function (err, keys) {


### PR DESCRIPTION
Use case: at each load time of Redis-commander, all the keys of the database are loaded because the default search pattern is "*". But on a large database, this is very broad and we load too much stuff, making the requests slow and Redis-Commander occasionnally crash.

Fix: I added an option "--root-pattern" to specifiy the search pattern for Redis keys that are displayed on the first load.

E.g. :
`redis-commander --root-pattern='country*'`

The list of available patterns are those of KEYS Redis command and can be found here: https://redis.io/commands/keys