### PR TITLE
switch docker image references from stevenaldinger to rediscommander

### DIFF
--- a/README.md
+++ b/README.md
@@ -59,7 +59,7 @@ services:
   redis-commander:
     container_name: redis-commander
     hostname: redis-commander
-    image: stevenaldinger/redis-commander:latest
+    image: rediscommander/redis-commander:latest
     build: .
     restart: always
     environment:
@@ -77,7 +77,7 @@ If you're running redis on `localhost:6379`, this is all you need to get started
 ```bash
 docker run --rm --name redis-commander -d \
   -p 8081:8081 \
-  stevenaldinger/redis-commander:latest
+  rediscommander/redis-commander:latest
 ```
 
 #### Specify single host
@@ -86,7 +86,7 @@ docker run --rm --name redis-commander -d \
 docker run --rm --name redis-commander -d \
   --env REDIS_HOSTS=10.10.20.30 \
   -p 8081:8081 \
-  stevenaldinger/redis-commander:latest
+  rediscommander/redis-commander:latest
 ```
 
 #### Specify multiple hosts with labels
@@ -95,5 +95,5 @@ docker run --rm --name redis-commander -d \
 docker run --rm --name redis-commander -d \
   --env REDIS_HOSTS=local:localhost:6379,myredis:10.10.20.30 \
   -p 8081:8081 \
-  stevenaldinger/redis-commander:latest
+  rediscommander/redis-commander:latest
 ```

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -8,7 +8,7 @@ services:
   redis-commander:
     container_name: redis-commander
     hostname: redis-commander
-    image: stevenaldinger/redis-commander:latest
+    image: rediscommander/redis-commander:latest
     build: .
     restart: always
     environment:


### PR DESCRIPTION
I think you have to either be an owner of a repository on Github or be in a Github organization to create automated builds for repos (not sure, never tried this before) but collaborator rights didn't make this repo available to me.

There's a [rediscommander](https://hub.docker.com/u/rediscommander/) organization as of this morning and [joeferner](https://hub.docker.com/u/joeferner/) and [stevenaldinger](https://hub.docker.com/u/stevenaldinger/) were both added as admins. Hyphens aren't allowed so `redis-commander` wasn't a valid organization name.

- DockerHub only supports [gravatar](https://en.gravatar.com/) for profile pictures and wasn't sure if redis-commander had one so that was left blank.
- I don't think the source repo on an automated build can be switched, you have to go through the whole process again (but it's short).
  1. Go to the [settings page](https://hub.docker.com/r/rediscommander/redis-commander/~/settings/)
  2. Scroll to the bottom and click "Delete" button under `Delete Repository`
  3. Go to the [automated builds](https://hub.docker.com/add/automated-build/rediscommander/github/orgs/) page for `rediscommander` and Github.
  4. Make sure `joeferner` is selected on the left and `redis-commander` repo in the list on the right.
  5. Add a short description, currently:
  > Alpine image for `redis-commander` Redis management tool.
  6. Click on save and then you're finished.