### PR TITLE
Bugfix: Default Connections not initializing db

### DIFF
--- a/bin/redis-commander.js
+++ b/bin/redis-commander.js
@@ -184,6 +184,9 @@ function startDefaultConnections (connections, callback) {
     connections.forEach(function (connection) {
       var client = new Redis(connection.port, connection.host);
       client.label = connection.label;
+      if(connection.dbIndex){
+        client.options.db = connection.dbIndex;
+      }
       redisConnections.push(client);
       if (connection.password) {
         redisConnections.getLast().auth(connection.password, function (err) {


### PR DESCRIPTION
Starting the default connections never actually retrieves the dbIndex into client from the connection object. This causes issues #195 and #196 because every connection that is started will be attempting to open a connection to database #0.