### PR TITLE
Fixed an issue for Redis authentication when using sentinels

### DIFF
--- a/bin/redis-commander.js
+++ b/bin/redis-commander.js
@@ -144,7 +144,12 @@ myUtils.getConfig(function (err, config) {
       if (!myUtils.containsConnection(config.default_connections, newDefault)) {
         var client;
         if (newDefault.sentinel_host) {
-          client = new Redis({showFriendlyErrorStack: true , sentinels: [{ host: newDefault.sentinel_host, port: newDefault.sentinel_port}],name: 'mymaster' });
+          client = new Redis({
+            showFriendlyErrorStack: true,
+            sentinels: [{host: newDefault.sentinel_host, port: newDefault.sentinel_port}],
+            password: newDefault.password,
+            name: 'mymaster'
+          });
         } else {
           client = new Redis({
             port: newDefault.port,


### PR DESCRIPTION
I fixed the issue ' ReplyError: NOAUTH Authentication required' when executing below command:

`redis-commander --redis-password <password> --sentinel-host <host> --sentinel-port <port>`

The solution is from the owner of ioredis https://github.com/luin/ioredis/issues/553#issuecomment-348690557

Related issue: https://github.com/joeferner/redis-commander/issues/179
