### PR TITLE
allow requiring externally

### DIFF
--- a/bin/redis-commander.js
+++ b/bin/redis-commander.js
@@ -233,10 +233,13 @@ function connectToDB (redisConnection, db) {
 }
 
 function startWebApp () {
-  httpServerOptions = {webPort: args.port, webAddress: args.address, username: args["http-auth-username"], password: args["http-auth-password"]};
+  httpServerOptions = {username: args["http-auth-username"], password: args["http-auth-password"]};
   if (args['save']) {
     args['nosave'] = false;
   }
   console.log("No Save: " + args["nosave"]);
-  app(httpServerOptions, redisConnections, args["nosave"], args['root-pattern']);
+  var appInstance = app(httpServerOptions, redisConnections, args["nosave"], args['root-pattern']);
+
+  appInstance.listen(args.port, args.address);
+  console.log("listening on ", args.address, ":", args.address);
 }

--- a/lib/app.js
+++ b/lib/app.js
@@ -60,10 +60,7 @@ module.exports = function (httpServerOptions, _redisConnections, nosave, rootPat
   app.use(app.router);
   app.use(express.static(staticPath));
   require('./routes')(app);
-
-  app.listen(httpServerOptions.webPort, httpServerOptions.webAddress);
-
-  console.log("listening on ", httpServerOptions.webAddress, ":", httpServerOptions.webPort);
+  return app;
 };
 
 function httpAuth (username, password) {

--- a/package.json
+++ b/package.json
@@ -19,6 +19,7 @@
     "redis-gui",
     "redis-node"
   ],
+  "main": "lib/app.js",
   "dependencies": {
     "async": "~0.1.22",
     "body-parser": "^1.15.2",


### PR DESCRIPTION
A minor change to be able to embed redis-commander inside existing apps.
For example:
```
const http = require('http');
const ioredis = require('ioredis');
const redisCommander = require('redis-commander');

const client = ioredis(); // 'redis://:secret@server:port/0'
client.label = 'default';

const appInstance = redisCommander({}, [client], true, '*');

const server = http.createServer((req, res) => {
  if (req.url === '/redis-admin') {
    res.writeHead(301, { Location: '/redis-admin/' });
    return res.end();
  }
  if (req.url.indexOf('/redis-admin/') === 0) {
    req.url = req.url.slice('/redis-admin'.length);
    return appInstance(req, res);
  }
  res.writeHead(302, { Location: 'https://xkcd.com' });
  return res.end();
});
server.listen(8080, console.log);
```
