### PR TITLE
fix graphical issue with wildcard in key name

### DIFF
--- a/lib/routes/apiv1.js
+++ b/lib/routes/apiv1.js
@@ -640,7 +640,7 @@ function getKeysTree (req, res, next) {
   console.log(sf('loading keys by prefix "{0}"', prefix));
   var search;
   if (prefix) {
-    search = prefix + foldingCharacter + '*';
+    search = prefix.replace("*", "\\*") + foldingCharacter + '*';
   } else {
     search = rootPattern;
   }


### PR DESCRIPTION
this fix addresses a graphical issue where if you have two keys e.g.
set abcdefghijk:abcdefghijk 123
set abc*:abcdefghijk 123
redis-commander will display a ghost child of abc* in the tree