### PR TITLE
optionally choose a specific jwt secret instead of a random one

### DIFF
--- a/lib/app.js
+++ b/lib/app.js
@@ -31,10 +31,9 @@ function equalStrings(a, b) {
   );
 }
 
-var jwtSecret = crypto.randomBytes(20).toString('base64');
 var usedTokens = new Set();
 
-function jwtSign(data) {
+function jwtSign(jwtSecret, data) {
   return new Promise((resolve, reject) => jwt.sign(data, jwtSecret, {
     "issuer": "Redis Commander",
     "subject": "Session Token",
@@ -42,7 +41,7 @@ function jwtSign(data) {
   }, (err, token) => (err ? reject(err) : resolve(token))));
 }
 
-function jwtVerify(token) {
+function jwtVerify(jwtSecret, token) {
   return new Promise(resolve => {
     jwt.verify(token, jwtSecret, {
       "issuer": "Redis Commander",
@@ -74,8 +73,9 @@ var viewsPath = path.join(__dirname, '../web/views');
 var staticPath = path.join(__dirname, '../web/static');
 var redisConnections = [];
 
-module.exports = function (httpServerOptions, _redisConnections, nosave, rootPattern) {
+module.exports = function (httpServerOptions, _redisConnections, nosave, rootPattern, defaultJwtSecret) {
   redisConnections = _redisConnections;
+  var jwtSecret = defaultJwtSecret || crypto.randomBytes(20).toString('base64');
   var app = express();
   app.use(partials());
   app.use(function(req, res, next) {
@@ -169,7 +169,7 @@ module.exports = function (httpServerOptions, _redisConnections, nosave, rootPat
           "ok": false
         });
       }
-      return Promise.all([jwtSign({}), jwtSign({
+      return Promise.all([jwtSign(jwtSecret, {}), jwtSign(jwtSecret, {
         "singleUse": true
       })])
       .then(([bearerToken, queryToken]) => res.json({
@@ -199,7 +199,7 @@ module.exports = function (httpServerOptions, _redisConnections, nosave, rootPat
       res.statusCode = 401;
       return res.end('Unauthorized - Missing Token');
     }
-    return jwtVerify(token)
+    return jwtVerify(jwtSecret, token)
     .then(success => {
       if (!success) {
         res.statusCode = 401;

--- a/lib/app.js
+++ b/lib/app.js
@@ -159,7 +159,7 @@ module.exports = function (httpServerOptions, _redisConnections, nosave, rootPat
       }
       var authorization = (req.get('Authorization') || '').split(/\s+/);
       if (/^Bearer$/i.test(authorization[0])) {
-        return new jwtVerify(authorization[1] || '');
+        return new jwtVerify(jwtSecret, authorization[1] || '');
       }
       return false;
     })

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "@awearsolutions/redis-commander",
-  "version": "0.4.5-rc.5",
+  "version": "0.4.5-rc.6",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "@awearsolutions/redis-commander",
-  "version": "0.4.5-rc.6",
+  "version": "0.4.5-rc.7",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -7,7 +7,7 @@
     "Matthew Scragg <scragg@gmail.com>"
   ],
   "name": "@awearsolutions/redis-commander",
-  "version": "0.4.5-rc.6",
+  "version": "0.4.5-rc.7",
   "description": "Redis web-based management tool written in node.js",
   "repository": {
     "type": "git",

--- a/package.json
+++ b/package.json
@@ -7,7 +7,7 @@
     "Matthew Scragg <scragg@gmail.com>"
   ],
   "name": "@awearsolutions/redis-commander",
-  "version": "0.4.5-rc.5",
+  "version": "0.4.5-rc.6",
   "description": "Redis web-based management tool written in node.js",
   "repository": {
     "type": "git",


### PR DESCRIPTION
Allows projects that import redis-commander to choose a specific jwt-secret.
I had an auto-scaling project that created multiple server instances, and a load-balancer routed each request to a different server. Obviously this is a problem when each server has its own randomly chosen jwt-secret...