### PR TITLE
Adding dumb-init

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -2,6 +2,12 @@ FROM node:9-alpine
 
 WORKDIR /redis-commander
 
+RUN  apk update \
+  && apk add ca-certificates wget \
+  && update-ca-certificates    \
+  && wget -O /usr/local/bin/dumb-init https://github.com/Yelp/dumb-init/releases/download/v1.2.1/dumb-init_1.2.1_amd64 \
+  && chmod +x /usr/local/bin/dumb-init
+
 COPY package.json .
 RUN npm install --production -s
 COPY lib ./lib
@@ -10,6 +16,7 @@ COPY bin ./bin
 COPY docker/entrypoint.sh .
 COPY docker/redis-commander.json .redis_commander
 
-ENTRYPOINT ["/redis-commander/entrypoint.sh"]
+ENTRYPOINT ["/usr/local/bin/dumb-init", "--"]
+CMD ["/redis-commander/entrypoint.sh"]
 
 EXPOSE 8081


### PR DESCRIPTION
This allows it to run a bit better, especially properly handle exit signals instead of needing to be force killed.

Every docker image should use proper init handling - this PR adds a transparent one which doesn't affect the operation but adds proper init functionality.