### PR TITLE
rewrite entrypoint.sh to honor all env vars on startup

### DIFF
--- a/docker/entrypoint.sh
+++ b/docker/entrypoint.sh
@@ -1,107 +1,127 @@
 #!/bin/sh
 
-# if REDIS_HOSTS isn't set just run the script
-[ -z "${REDIS_HOSTS}" ] && exec node ./bin/redis-commander "$@"
+CONFIG_FILE=${HOME}/.redis-commander
 
-echo 'Creating custom redis-commander config.'
+writeDefaultConfigBeginning() {
+    echo 'Creating custom redis-commander config.'
 
-# =============== generate beginning of redis-commander config =============== #
-cat > ${HOME}/.redis-commander <<EOF
-{
-  "sidebarWidth":250,
-  "locked":false,
-  "CLIHeight":50,
-  "CLIOpen":false,
-  "default_connections": [
+    # =============== generate beginning of redis-commander config =============== #
+    cat > ${CONFIG_FILE} <<EOF
+    {
+    "sidebarWidth":250,
+    "locked":false,
+    "CLIHeight":50,
+    "CLIOpen":false,
+    "default_connections": [
 EOF
-# ============= end generate beginning of redis-commander config ============= #
-
-# split REDIS_HOSTS on comma (,)
-# local:localhost:6379,custom-label:my.hostname
-#   -> local:localhost:6379 custom-label:my.hostname
-redis_hosts_split="$(echo ${REDIS_HOSTS} | sed "s/,/ /g")"
-
-# get hosts count
-num_redis_hosts="$(echo ${redis_hosts_split} | wc -w)"
-
-# =================== loop on redis hosts and generate config ================ #
-# redis_host form should be
-#   hostname
-#     or
-#   label:hostname
-#     or
-#   label:hostname:port
-#     or
-#   label:hostname:port:dbIndex
-#     or
-#   label:hostname:port:dbIndex:password
-counter=0
-for redis_host in ${redis_hosts_split}; do
-  counter=$((counter + 1))
-
-  # split redis_host on colon (:)
-  # local:localhost:6379
-  #   -> local localhost 6379
-  host_split="$(echo ${redis_host} | sed "s/:/ /g")"
-
-  # get host param count
-  num_host_params="$(echo "${host_split}" | wc -w)"
-
-  label=''
-  host=''
-  port=''
-  db_index=''
-  password=''
-
-  if [ "${num_host_params}" -eq 1 ]; then
-    label=default
-    host="$(echo ${host_split} | cut -d" " -f1)"
-  else
-    label="$(echo ${host_split} | cut -d" " -f1)"
-    host="$(echo ${host_split} | cut -d" " -f2)"
-  fi
-
-  [ "${num_host_params}" -lt 3 ] \
-    && port=6379 \
-    || port="$(echo ${host_split} | cut -d" " -f3)"
-
-  [ "${num_host_params}" -lt 4 ] \
-    && db_index=0 \
-    || db_index="$(echo ${host_split} | cut -d" " -f4)"
-
-
-  [ "${num_host_params}" -lt 5 ] \
-    && password='' \
-    || password="$(echo ${host_split} | cut -d" " -f5)"
-
-  [ "${counter}" -eq "${num_redis_hosts}" ] \
-    && comma='' \
-    || comma=','
-
-    # generate host config
-    cat >> ${HOME}/.redis-commander <<EOF
-      {
-        "label":"${label}",
-        "host":"${host}",
-        "port":"${port}",
-        "password":"${password}",
-        "dbIndex":${db_index}
-      }${comma}
-EOF
-
-done
-# ================ end loop on redis hosts and generate config =============== #
-
-
-# ================== generate end of redis-commander config ================== #
-cat >> ${HOME}/.redis-commander <<EOF
-  ]
+    # ============= end generate beginning of redis-commander config ============= #
 }
+
+
+writeDefaultConfigEnd() {
+    # ================== generate end of redis-commander config ================== #
+    cat >> ${CONFIG_FILE} <<EOF
+        ]
+    }
 EOF
-# ================ end generate end of redis-commander config ================ #
+    # ================ end generate end of redis-commander config ================ #
+}
+
+
+parseRedisHosts() {
+    writeDefaultConfigBeginning
+    
+    # split REDIS_HOSTS on comma (,)
+    # local:localhost:6379,custom-label:my.hostname
+    #   -> local:localhost:6379 custom-label:my.hostname
+    redis_hosts_split="$(echo ${REDIS_HOSTS} | sed "s/,/ /g")"
+    
+    # get hosts count
+    num_redis_hosts="$(echo ${redis_hosts_split} | wc -w)"
+
+    # =================== loop on redis hosts and generate config ================ #
+    # redis_host form should be
+    #   hostname
+    #     or
+    #   label:hostname
+    #     or
+    #   label:hostname:port
+    #     or
+    #   label:hostname:port:dbIndex
+    #     or
+    #   label:hostname:port:dbIndex:password
+    counter=0
+    for redis_host in ${redis_hosts_split}; do
+        counter=$((counter + 1))
+
+        # split redis_host on colon (:)
+        # local:localhost:6379
+        #   -> local localhost 6379
+        host_split="$(echo ${redis_host} | sed "s/:/ /g")"
+    
+        # get host param count
+        num_host_params="$(echo "${host_split}" | wc -w)"
+
+        label=''
+        host=''
+        port=''
+        db_index=''
+        password=''
+
+        if [ "${num_host_params}" -eq 1 ]; then
+            label=default
+            host="$(echo ${host_split} | cut -d" " -f1)"
+        else
+            label="$(echo ${host_split} | cut -d" " -f1)"
+            host="$(echo ${host_split} | cut -d" " -f2)"
+        fi
+
+        [ "${num_host_params}" -lt 3 ] \
+            && port=6379 \
+            || port="$(echo ${host_split} | cut -d" " -f3)"
+
+        [ "${num_host_params}" -lt 4 ] \
+            && db_index=0 \
+            || db_index="$(echo ${host_split} | cut -d" " -f4)"
+
+
+        [ "${num_host_params}" -lt 5 ] \
+            && password='' \
+            || password="$(echo ${host_split} | cut -d" " -f5)"
+
+        [ "${counter}" -eq "${num_redis_hosts}" ] \
+            && comma='' \
+            || comma=','
+
+        # generate host config
+        cat >> ${CONFIG_FILE} <<EOF
+        {
+            "label":"${label}",
+            "host":"${host}",
+            "port":"${port}",
+            "password":"${password}",
+            "dbIndex":${db_index}
+        }${comma}
+EOF
+
+    done
+    # ================ end loop on redis hosts and generate config =============== #
+    
+    writeDefaultConfigEnd
+}
+
+# if REDIS_HOSTS is set parse it and create custom config
+[[ ! -z "${REDIS_HOSTS}" ]] && parseRedisHosts
+
+# Fallback - write default config if not supplied otherwise (already exists or written by
+# parsing REDIS_HOSTS env var)
+if [[ ! -e ${CONFIG_FILE} ]]; then
+    writeDefaultConfigBeginning
+    writeDefaultConfigEnd
+fi
 
 echo 'Configuration:'
-cat ${HOME}/.redis-commander
+cat ${CONFIG_FILE}
 
 # add other commands as environment variables
 if [[ ! -z "$REDIS_PORT" ]]; then


### PR DESCRIPTION
Hello,

i've change the docker entrypoint.sh script to pick up all environment vars even if no REDIS_HOSTS env var is supplied. The old version skips parsing the env vars if no REDIS_HOSTS is set and ignores all other REDIS_* vars too.

Now the docker startup is in line again with the README stating all possible env vars.

Thanks,
S. Seide