### PR TITLE
Provide support for file-based HTTP password initialization

### DIFF
--- a/docker/entrypoint.sh
+++ b/docker/entrypoint.sh
@@ -123,6 +123,14 @@ fi
 echo 'Configuration:'
 cat ${CONFIG_FILE}
 
+# load HTTP password from a file (e.g. a Docker secret mounted in the container)
+HTTP_PASSWORD_FILE=${HTTP_PASSWORD_FILE:-/}
+
+if [ -f $HTTP_PASSWORD_FILE ]; then
+    HTTP_PASSWORD=$(cat $HTTP_PASSWORD_FILE)
+    export HTTP_PASSWORD="$HTTP_PASSWORD"
+fi
+
 # add other commands as environment variables
 if [[ ! -z "$REDIS_PORT" ]]; then
     set -- "$@" "--redis-port $REDIS_PORT"


### PR DESCRIPTION
This PR defines a `HTTP_PASSWORD_FILE` environment variable, which can be used to load the HTTP password from a Docker secret stored in `/run/secrets/<secret_name>` in the context of a Docker Swarm setup.

A sample Compose file to illustrate this:

```
version: "3.5"
services:
  redis:
    image: redis:4.0.2-alpine
  rediscommander:
    image: rediscommander/redis-commander:latest
    environment:
      - REDIS_HOSTS=local:redis:6379
      - HTTP_USER=someusername
      - HTTP_PASSWORD_FILE=/run/secrets/rediscommander_http_password
    secrets:
      - rediscommander_http_password
secrets:
  rediscommander_http_password:
    external: true
```