### PR TITLE
Allow changing tree view folding character via command line

### DIFF
--- a/README.md
+++ b/README.md
@@ -155,8 +155,6 @@ containers:
   env:
   - name: REDIS_HOSTS
     value: instance1:redis:6379
-  - name: K8S_SIGTERM
-    value: 1  
   ports:
   - name: redis-commander
     containerPort: 8081

--- a/README.md
+++ b/README.md
@@ -28,13 +28,14 @@ Options:
   --address, -a                        The address to run the server on.        [string]  [default: 0.0.0.0]
   --port, -p                           The port to run the server on.           [string]  [default: 8081]
   --url-prefix, -u                     The url prefix to respond on.            [string]  [default: ""]
-  --root-pattern, -rp                  The root pattern of the redis keys.      [string]  [default: *]
-  --nosave, -ns                        Do not save new connections to config.   [boolean] [default: true]
-  --noload, -nl                        Do not load connections from config.     [boolean] [default: false]
-  --use-scan, -sc                      Use scan instead of keys.                [boolean] [default: false]
-  --clear-config, -cc                  clear configuration file.                [boolean] [default: false]
-  --scan-count, -sc                    The size of each seperate scan.          [integer] [default: 100]
+  --root-pattern, --rp                 The root pattern of the redis keys.      [string]  [default: "*"]
+  --nosave, --ns                       Do not save new connections to config.   [boolean] [default: true]
+  --noload, --nl                       Do not load connections from config.     [boolean] [default: false]
+  --use-scan, --sc                     Use scan instead of keys.                [boolean] [default: false]
+  --clear-config, --cc                 clear configuration file.                [boolean] [default: false]
+  --scan-count, --sc                   The size of each seperate scan.          [integer] [default: 100]
   --no-log-data                        Do not log data values from redis store. [boolean] [default: false]
+  --folding-char, --fc                 Character to fold keys at in tree view.  [character] [default: ":"]
 ```
 
 The connection can be established either via direct connection to redis server or indirect 
@@ -61,6 +62,7 @@ ADDRESS
 ROOT_PATTERN
 URL_PREFIX
 NO_LOG_DATA
+FOLDING_CHAR
 K8S_SIGTERM
 ```
 
@@ -153,6 +155,8 @@ containers:
   env:
   - name: REDIS_HOSTS
     value: instance1:redis:6379
+  - name: K8S_SIGTERM
+    value: 1  
   ports:
   - name: redis-commander
     containerPort: 8081

--- a/bin/redis-commander.js
+++ b/bin/redis-commander.js
@@ -118,6 +118,20 @@ let args = optimist
     default: false,
     describe: 'Do not log data values from redis store.'
   })
+  .options('folding-char', {
+    alias: 'fc',
+    boolean: false,
+    describe: 'Character to fold keys at for tree view.',
+    default: ':'
+  })
+  .check(function(value) {
+      switch (value['folding-char']) {
+        case '&':
+        case '?':
+        case '*':
+          throw new Error('Characters &, ? and * are invalid for param folding-char!');
+      }
+  })
   .argv;
 
 if (args.help) {
@@ -285,7 +299,13 @@ function startWebApp () {
     process.exit();
   }
   console.log("No Save: " + args["nosave"]);
-  let appInstance = app(httpServerOptions, redisConnections, args["nosave"], args['root-pattern'], (args['log-data']===false));
+  let appOptions = {
+    noSave: args["nosave"],
+    rootPattern: args['root-pattern'],
+    noLogData: (args['log-data']===false),
+    foldingChar: args['folding-char']
+  };
+  let appInstance = app(httpServerOptions, redisConnections, appOptions);
 
   appInstance.listen(args.port, args.address, function() {
     console.log("listening on ", args.address, ":", args.port);

--- a/docker/entrypoint.sh
+++ b/docker/entrypoint.sh
@@ -202,6 +202,10 @@ if [[ ! -z "$NO_LOG_DATA" ]]; then
     set -- "$@" "--no-log-data"
 fi
 
+if [[ ! -z "$FOLDING_CHAR" ]]; then
+    set -- "$@" "--folding-char $FOLDING_CHAR"
+fi
+
 # install trap for SIGTERM to delay end of app a bit for kubernetes
 # otherwise container might get requests after exiting itself
 exitTrap() {

--- a/lib/app.js
+++ b/lib/app.js
@@ -74,10 +74,10 @@ let viewsPath = path.join(__dirname, '../web/views');
 let staticPath = path.join(__dirname, '../web/static');
 let redisConnections = [];
 
-module.exports = function (httpServerOptions, _redisConnections, nosave, rootPattern, noLogData, defaultJwtSecret) {
+module.exports = function (httpServerOptions, _redisConnections, _appOptions) {
   const urlPrefix = httpServerOptions.urlPrefix || '';
   redisConnections = _redisConnections;
-  let jwtSecret = defaultJwtSecret || crypto.randomBytes(20).toString('base64');
+  let jwtSecret = _appOptions.defaultJwtSecret || crypto.randomBytes(20).toString('base64');
 
   let app = express();
   app.disable('x-powered-by');
@@ -96,7 +96,7 @@ module.exports = function (httpServerOptions, _redisConnections, nosave, rootPat
   });
 
   app.getConfig = myUtils.getConfig;
-  if (!nosave) {
+  if (!_appOptions.noSave) {
      app.saveConfig = myUtils.saveConfig;
   } else {
      app.saveConfig = function (config, callback) { callback(null) };
@@ -106,8 +106,9 @@ module.exports = function (httpServerOptions, _redisConnections, nosave, rootPat
 
   app.locals.layoutFilename = path.join(__dirname, '../web/views/layout.ejs');
   app.locals.redisConnections = redisConnections;
-  app.locals.rootPattern = rootPattern;
-  app.locals.noLogData = noLogData;
+  app.locals.rootPattern = _appOptions.rootPattern;
+  app.locals.noLogData = _appOptions.noLogData;
+  app.locals.foldingCharacter = _appOptions.foldingChar;
 
   app.set('views', viewsPath);
   app.set('view engine', 'ejs');

--- a/lib/routes/apiv1.js
+++ b/lib/routes/apiv1.js
@@ -10,7 +10,7 @@ let rootPattern;
 
 module.exports = function (app, urlPrefix) {
   rootPattern = app.locals.rootPattern;
-  foldingCharacter = ':';
+  foldingCharacter = app.locals.foldingCharacter;
   let router = express.Router();
   app.use(`${urlPrefix}/apiv1`, router);
 

--- a/lib/routes/apiv1.js
+++ b/lib/routes/apiv1.js
@@ -3,28 +3,42 @@
 let sf = require('sf');
 let async = require('async');
 let inflection = require('inflection');
+let express = require('express');
 let myutil = require('../util');
-let foldingCharacter = ":";
+let foldingCharacter;
 let rootPattern;
 
 module.exports = function (app, urlPrefix) {
   rootPattern = app.locals.rootPattern;
-  app.get(`${urlPrefix}/apiv1/server/info`, getServersInfo);
-  app.get(`${urlPrefix}/apiv1/key/:connectionId/:key/:index?`, getKeyDetails);
-  app.post(`${urlPrefix}/apiv1/key/:connectionId/:key`, postKey);
-  app.post(`${urlPrefix}/apiv1/keys/:connectionId/:key`, postKeys);
-  app.post(`${urlPrefix}/apiv1/listvalue/`, postAddListValue);
-  app.post(`${urlPrefix}/apiv1/setmember/`, postAddSetMember);
-  app.post(`${urlPrefix}/apiv1/editListRow`, postEditListRow);
-  app.post(`${urlPrefix}/apiv1/editSetMember`, postEditSetMember);
-  app.post(`${urlPrefix}/apiv1/editZSetRow`, postEditZSetRow);
-  app.post(`${urlPrefix}/apiv1/editHashRow`, postEditHashRow);
-  app.post(`${urlPrefix}/apiv1/encodeString/:stringValue`, encodeString);
-  app.get(`${urlPrefix}/apiv1/keystree/:connectionId/:keyPrefix`, getKeysTree);
-  app.get(`${urlPrefix}/apiv1/keystree/:connectionId`, getKeysTree);
-  app.get(`${urlPrefix}/apiv1/keys/:connectionId/:keyPrefix`, getKeys);
-  app.post(`${urlPrefix}/apiv1/exec`, postExec);
-  app.get(`${urlPrefix}/apiv1/connection`, isConnected);
+  foldingCharacter = ':';
+  let router = express.Router();
+  app.use(`${urlPrefix}/apiv1`, router);
+
+  // ATTN: behaviour of (*) in route name will change in Express 5.x
+  //   https://github.com/expressjs/express/issues/2495
+  //
+  // syntax /key/:key(*) is used to allow redis keys with "/" in it too
+  // example: redis key a/b/c -> url /key/a/b/c -> param key='a/b/c'
+  // route tester ui: https://wesleytodd.github.io/express-route-tester/
+  router.get('/server/info', getServersInfo);
+  // moved index url param to query param to allow keys with '/'
+  router.get('/key/:connectionId/:key(*)', getKeyDetails);
+  router.post('/key/:connectionId/:key(*)', postKey);
+  router.post('/keys/:connectionId/:key(*)', postKeys);
+  router.post('/listvalue/', postAddListValue);
+  router.post('/setmember/', postAddSetMember);
+  router.post('/editListRow', postEditListRow);
+  router.post('/editSetMember', postEditSetMember);
+  router.post('/editZSetRow', postEditZSetRow);
+  router.post('/editHashRow', postEditHashRow);
+  router.post('/encodeString/:stringValue', encodeString);
+  router.get('/keystree/:connectionId/:keyPrefix(*)', getKeysTree);
+  router.get('/keystree/:connectionId', getKeysTree);
+  router.get('/keys/:connectionId/:keyPrefix(*)', getKeys);
+  router.post('/exec', postExec);
+  router.get('/connection', isConnected);
+
+  router.param('connectionId', getConnection)
 };
 
 function isConnected (req, res) {
@@ -34,17 +48,36 @@ function isConnected (req, res) {
   return res.send(false);
 }
 
-function getConnection (redisConnections, connectionId, callback) {
+/** method called to extract url parameter 'connectionId' from all routes.
+ *  The connection object found is attached to the res.locals.connection variable for all
+ *  following routes to work with. The connectionId param is attached to res.locals.connectionId.
+ *
+ *  This method exits with JSON error response if no connection is found.
+ *
+ * @param {object} req Express request object
+ * @param {object} res Express response object
+ * @param {function} next The next middleware function to call
+ * @param {string} connectionId The value of the connectionId parameter.
+ */
+function getConnection (req, res, next, connectionId) {
   let connectionIds = connectionId.split(":");
   let desiredHost = connectionIds[0];
   let desiredPort = parseInt(connectionIds[1]);
   let desiredDb = parseInt(connectionIds[2]);
-  let con = redisConnections.find(function(connection) {
+  let con = req.app.locals.redisConnections.find(function(connection) {
     return (connection.options.host === desiredHost && connection.options.port === desiredPort && connection.options.db === desiredDb);
   });
-  if (!con) console.error('Connection with id ' + connectionId + ' not found.');
-  return callback(null, con);
+  if (con) {
+    res.locals.connection = con;
+    res.locals.connectionId = connectionId;
+  }
+  else {
+    console.error('Connection with id ' + connectionId + ' not found.');
+    printError(res, next, null, req.originalUrl);
+  }
+  next();
 }
+
 
 function getServersInfo (req, res, next) {
   if (req.app.locals.redisConnections.length > 0) {
@@ -67,7 +100,7 @@ function getServersInfo (req, res, next) {
       });
     });
   } else {
-    return next("No redis connection");
+    return next("No redis connections");
   }
 }
 
@@ -103,57 +136,51 @@ function getServerInfo (redisConnection, callback) {
 
 function postExec (req, res) {
   let cmd = req.body.cmd;
-  let connectionId = req.body.connection;
-  getConnection(req.app.locals.redisConnections, connectionId, function (err, connection) {
-    if (err || !redisConnection) printError(res, null, err, 'postExec');
-    let parts = myutil.split(cmd);
-    parts[0] = parts[0].toLowerCase();
-    let commandName = parts[0].toLowerCase();
-    if (!(commandName in connection)) {
-        return res.send('ERROR: Invalid Command');
-    }
-    let args = parts.slice(1);
-    args.push(function (err, results) {
-        if (err) {
-            return res.send(err.message);
-        }
-        return res.send(JSON.stringify(results));
-    });
-    connection[commandName].apply(connection, args);
+  let connection = res.locals.connection;
+  let parts = myutil.split(cmd);
+  parts[0] = parts[0].toLowerCase();
+  let commandName = parts[0].toLowerCase();
+  if (!(commandName in connection)) {
+      return res.send('ERROR: Invalid Command');
+  }
+  let args = parts.slice(1);
+  args.push(function (err, results) {
+      if (err) {
+          return res.send(err.message);
+      }
+      return res.send(JSON.stringify(results));
   });
+  connection[commandName].apply(connection, args);
 }
 
 function getKeyDetails (req, res, next) {
-  let connectionId = req.params.connectionId;
   let key = req.params.key;
-  getConnection(req.app.locals.redisConnections, connectionId, function (err, redisConnection) {
-    if (err || !redisConnection) printError(res, null, err, 'getKeyDetails');
-    console.log(sf('loading key "{0}" from "{1}"', key, connectionId));
-    redisConnection.type(key, function (err, type) {
-      if (err) {
-        console.error('getKeyDetails', err);
-        return next(err);
-      }
+  let redisConnection = res.locals.connection;
+  console.log(sf('loading key "{0}" from "{1}"', key, res.locals.connectionId));
+  redisConnection.type(key, function (err, type) {
+    if (err) {
+      console.error('getKeyDetails', err);
+      return next(err);
+    }
 
-      switch (type) {
-        case 'string':
-          return getKeyDetailsString(key, redisConnection, res, next);
-        case 'list':
-          return getKeyDetailsList(key, redisConnection, req, res, next);
-        case 'zset':
-          return getKeyDetailsZSet(key, redisConnection, req, res, next);
-        case 'hash':
-          return getKeyDetailsHash(key, redisConnection, res, next);
-        case 'set':
-          return getKeyDetailsSet(key, redisConnection, res, next);
-      }
+    switch (type) {
+      case 'string':
+        return getKeyDetailsString(key, res, next);
+      case 'list':
+        return getKeyDetailsList(key, req, res, next);
+      case 'zset':
+        return getKeyDetailsZSet(key, req, res, next);
+      case 'hash':
+        return getKeyDetailsHash(key, res, next);
+      case 'set':
+        return getKeyDetailsSet(key, res, next);
+    }
 
-      let details = {
-        key: key,
-        type: type
-      };
-      res.send(JSON.stringify(details));
-    });
+    let details = {
+      key: key,
+      type: type
+    };
+    res.send(JSON.stringify(details));
   });
 }
 
@@ -169,7 +196,8 @@ function sendWithTTL(details, key, redisConnection, res) {
     });
 }
 
-function getKeyDetailsString (key, redisConnection, res, next) {
+function getKeyDetailsString (key, res, next) {
+  let redisConnection = res.locals.connection;
   redisConnection.get(key, function (err, val) {
     if (err) {
       console.error('getKeyDetailsString', err);
@@ -185,8 +213,9 @@ function getKeyDetailsString (key, redisConnection, res, next) {
   });
 }
 
-function getKeyDetailsList (key, redisConnection, req, res, next) {
-  let startIdx = parseInt(req.params.index, 10);
+function getKeyDetailsList (key, req, res, next) {
+  let redisConnection = res.locals.connection;
+  let startIdx = parseInt(req.query.index, 10);
   if (typeof(startIdx) === 'undefined' || isNaN(startIdx) || startIdx < 0) {
     startIdx = 0;
   }
@@ -222,7 +251,8 @@ function getKeyDetailsList (key, redisConnection, req, res, next) {
   });
 }
 
-function getKeyDetailsHash (key, redisConnection, res, next) {
+function getKeyDetailsHash (key, res, next) {
+  let redisConnection = res.locals.connection;
   redisConnection.hgetall(key, function (err, fieldsAndValues) {
     if (err) {
       console.error('getKeyDetailsHash', err);
@@ -238,7 +268,8 @@ function getKeyDetailsHash (key, redisConnection, res, next) {
   });
 }
 
-function getKeyDetailsSet (key, redisConnection, res, next) {
+function getKeyDetailsSet (key, res, next) {
+  let redisConnection = res.locals.connection;
   redisConnection.smembers(key, function (err, members) {
     if (err) {
       console.error('getKeyDetailsSet', err);
@@ -254,8 +285,9 @@ function getKeyDetailsSet (key, redisConnection, res, next) {
   });
 }
 
-function getKeyDetailsZSet (key, redisConnection, req, res, next) {
-  let startIdx = parseInt(req.params.index, 10);
+function getKeyDetailsZSet (key, req, res, next) {
+  let redisConnection = res.locals.connection;
+  let startIdx = parseInt(req.query.index, 10);
   if (typeof(startIdx) === 'undefined' || isNaN(startIdx) || startIdx < 0) {
     startIdx = 0;
   }
@@ -290,10 +322,9 @@ function postAddListValue (req, res, next) {
   let value = req.body.stringValue;
   let type = req.body.type;
   let connectionId = req.body.listConnectionId;
-  getConnection(req.app.locals.redisConnections, connectionId, function (err, redisConnection) {
-    if (err || !redisConnection) return printError(res, next, err, 'postAddListValue');
-    addListValue(redisConnection, key, value, type, res, next);
-  });
+  getConnection(req, res, function () {
+    addListValue(res.locals.connection, key, value, type, res, next);
+  }, connectionId);
 }
 
 function postEditListRow (req, res, next) {
@@ -301,10 +332,9 @@ function postEditListRow (req, res, next) {
   let index = req.body.listIndex;
   let value = req.body.listValue;
   let connectionId = req.body.listConnectionId;
-  getConnection(req.app.locals.redisConnections, connectionId, function (err, redisConnection) {
-    if (err || !redisConnection) return printError(res, next, err, 'postEditListRow');
+  getConnection(req, res, function () {
     editListRow(redisConnection, key, index, value, res, next);
-  });
+  }, connectionId);
 }
 
 function postEditSetMember (req, res, next) {
@@ -312,10 +342,9 @@ function postEditSetMember (req, res, next) {
   let member = req.body.setMember;
   let oldMember = req.body.setOldMember;
   let connectionId = req.body.setConnectionId;
-  getConnection(req.app.locals.redisConnections, connectionId, function (err, redisConnection) {
-    if (err || !redisConnection) return printError(res, next, err, 'postEditSetMember');
+  getConnection(req, res, function () {
     editSetMember(redisConnection, key, member, oldMember, res, next);
-  });
+  }, connectionId);
 }
 
 function postEditZSetRow (req, res, next) {
@@ -324,10 +353,9 @@ function postEditZSetRow (req, res, next) {
   let value = req.body.zSetValue;
   let oldValue = req.body.zSetOldValue;
   let connectionId = req.body.zSetConnectionId;
-  getConnection(req.app.locals.redisConnections, connectionId, function (err, redisConnection) {
-    if (err || !redisConnection) return printError(res, next, err, 'postEditZSetRow');
+  getConnection(req, res, function () {
     editZSetRow(redisConnection, key, score, value, oldValue, res, next);
-  });
+  }, connectionId);
 }
 
 function postEditHashRow (req, res, next) {
@@ -335,20 +363,18 @@ function postEditHashRow (req, res, next) {
   let field = req.body.hashField;
   let value = req.body.hashFieldValue;
   let connectionId = req.body.hashConnectionId;
-  getConnection(req.app.locals.redisConnections, connectionId, function (err, redisConnection) {
-    if (err || !redisConnection) return printError(res, next, err, 'postEditHashRow');
+  getConnection(req, res, function () {
     editHashRow(redisConnection, key, field, value, res, next);
-  });
+  }, connectionId);
 }
 
 function postAddSetMember (req, res, next) {
   let key = req.body.setKey;
   let member = req.body.setMemberName;
   let connectionId = req.body.setConnectionId;
-  getConnection(req.app.locals.redisConnections, connectionId, function(err, redisConnection) {
-    if (err || !redisConnection) return printError(res, next, err, 'postAddSetMember');
+  getConnection(req, res, function() {
     addSetMember(redisConnection, key, member, res, next);
-  });
+  }, connectionId);
 }
 
 function addSetMember (redisConnection, key, member, res, next) {
@@ -498,21 +524,19 @@ function editHashRow (redisConnection, key, field, value, res, next) {
 
 
 function postKey (req, res, next) {
-  let connectionId = req.params.connectionId;
-  getConnection(req.app.locals.redisConnections, connectionId, function (err, redisConnection) {
-    if (err || !redisConnection) return printError(res, next, err, 'postKey');
-    if (req.query.action === 'delete') {
-      deleteKey(redisConnection, req, next, res);
-    } else if (req.query.action === 'decode') {
-      decodeKey(redisConnection, req, next, res);
-    } else {
-      saveKey(redisConnection, req, next, res);
-    }
-  });
+  if (req.query.action === 'delete') {
+    deleteKey(req, res, next);
+  } else if (req.query.action === 'decode') {
+    decodeKey(req, res, next);
+  } else {
+    saveKey(req, res, next);
+  }
 }
 
-function saveKey (redisConnection, req, next, res) {
+function saveKey (req, res, next) {
   let key = req.params.key;
+  let redisConnection = res.locals.connection;
+
   console.log(sf('saving key "{0}"', key));
   redisConnection.type(key, function (err, type) {
     if (err) {
@@ -540,8 +564,9 @@ function saveKey (redisConnection, req, next, res) {
   });
 }
 
-function decodeKey (redisConnection, req, next, res) {
+function decodeKey (req, res, next) {
   let key = req.params.key;
+  let redisConnection = res.locals.connection;
 
   redisConnection.get(key, function (err, val) {
     if (err) {
@@ -578,8 +603,9 @@ function encodeString (req, res, next) {
   return res.send(encoded)
 }
 
-function deleteKey (redisConnection, req, next, res) {
+function deleteKey (req, res, next) {
   let key = req.params.key;
+  let redisConnection = res.locals.connection;
   console.log(sf('deleting key "{0}"', key));
   redisConnection.del(key, function (err) {
     if (err) {
@@ -603,42 +629,39 @@ function posKeyDetailsString (redisConnection, key, value, req, res, next) {
 }
 
 function getKeys (req, res, next) {
-  let connectionId = req.params.connectionId;
-  getConnection(req.app.locals.redisConnections, connectionId, function (err, redisConnection) {
-    if (err || !redisConnection) return printError(res, next, err, 'getKeys');
-    let prefix = req.params.keyPrefix;
-    let limit = req.params.limit || 100;
-    console.log(sf('loading keys by prefix "{0}"', prefix));
-    redisConnection.keys(prefix, function (err, keys) {
-      if (err) {
-        console.error('getKeys', err);
-        return next(err);
-      }
-      console.log(sf('found {0} keys for "{1}"', keys.length, prefix));
+  let prefix = req.params.keyPrefix;
+  let limit = req.params.limit || 100;
+  let redisConnection = res.locals.connection;
+  console.log(sf('loading keys by prefix "{0}"', prefix));
+  redisConnection.keys(prefix, function (err, keys) {
+    if (err) {
+      console.error('getKeys', err);
+      return next(err);
+    }
+    console.log(sf('found {0} keys for "{1}"', keys.length, prefix));
 
-      if (keys.length > 1) {
-        keys = myutil.distinct(keys.map(function (key) {
-          let idx = key.indexOf(foldingCharacter, prefix.length);
-          if (idx > 0) {
-            return key.substring(0, idx + 1);
-          }
-          return key;
-        }));
-      }
+    if (keys.length > 1) {
+      keys = myutil.distinct(keys.map(function (key) {
+        let idx = key.indexOf(foldingCharacter, prefix.length);
+        if (idx > 0) {
+          return key.substring(0, idx + 1);
+        }
+        return key;
+      }));
+    }
 
-      if (keys.length > limit) {
-        keys = keys.slice(0, limit);
-      }
+    if (keys.length > limit) {
+      keys = keys.slice(0, limit);
+    }
 
-      keys = keys.sort();
-      res.send(JSON.stringify(keys));
-    });
+    keys = keys.sort();
+    res.send(JSON.stringify(keys));
   });
 }
 
 function getKeysTree (req, res, next) {
-  let connectionId = req.params.connectionId;
   let prefix = req.params.keyPrefix;
+  let redisConnection = res.locals.connection;
   console.log(sf('loading keys by prefix "{0}"', prefix));
   let search;
   if (prefix) {
@@ -646,104 +669,99 @@ function getKeysTree (req, res, next) {
   } else {
     search = rootPattern;
   }
-  getConnection(req.app.locals.redisConnections, connectionId, function (err, redisConnection) {
-      if (err || !redisConnection) return printError(res, next, err, 'getKeysTree');
-      redisConnection.keys(search, function (err, keys) {
+
+  redisConnection.keys(search, function (err, keys) {
+    if (err) {
+      console.error('getKeys', err);
+      return next(err);
+    }
+    console.log(sf('found {0} keys for "{1}"', keys.length, prefix));
+
+    let lookup = {};
+    let reducedKeys = [];
+    keys.forEach(function (key) {
+      let fullKey = key;
+      if (prefix) {
+        key = key.substr((prefix + foldingCharacter).length);
+      }
+      let parts = key.split(foldingCharacter);
+      let firstPrefix = parts[0];
+      if (lookup.hasOwnProperty(firstPrefix)) {
+        lookup[firstPrefix].count++;
+      } else {
+        lookup[firstPrefix] = {
+          attr: { id: firstPrefix },
+          count: parts.length === 1 ? 0 : 1
+        };
+        lookup[firstPrefix].fullKey = fullKey;
+        if (parts.length === 1) {
+          lookup[firstPrefix].leaf = true;
+        }
+        reducedKeys.push(lookup[firstPrefix]);
+      }
+    });
+
+    reducedKeys.forEach(function (data) {
+      if (data.count === 0) {
+        data.data = data.attr.id;
+      } else {
+        data.data = data.attr.id + ":* (" + data.count + ")";
+        data.state = "closed";
+      }
+    });
+
+    async.forEachLimit(reducedKeys, 10, function (keyData, callback) {
+      if (keyData.leaf) {
+        redisConnection.type(keyData.fullKey, function (err, type) {
+          if (err) {
+            return callback(err);
+          }
+          keyData.attr.rel = type;
+          let sizeCallback = function (err, count) {
+            if (err) {
+              return callback(err);
+            } else {
+              keyData.data += " (" + count + ")";
+              callback();
+            }
+          };
+          if (type === 'list') {
+            redisConnection.llen(keyData.fullKey, sizeCallback);
+          } else if (type === 'set') {
+            redisConnection.scard(keyData.fullKey, sizeCallback);
+          } else if (type === 'zset') {
+            redisConnection.zcard(keyData.fullKey, sizeCallback);
+          } else {
+            callback();
+          }
+        });
+      } else {
+        callback();
+      }
+    }, function (err) {
       if (err) {
         console.error('getKeys', err);
         return next(err);
       }
-      console.log(sf('found {0} keys for "{1}"', keys.length, prefix));
-
-      let lookup = {};
-      let reducedKeys = [];
-      keys.forEach(function (key) {
-        let fullKey = key;
-        if (prefix) {
-          key = key.substr((prefix + foldingCharacter).length);
-        }
-        let parts = key.split(foldingCharacter);
-        let firstPrefix = parts[0];
-        if (lookup.hasOwnProperty(firstPrefix)) {
-          lookup[firstPrefix].count++;
-        } else {
-          lookup[firstPrefix] = {
-            attr: { id: firstPrefix },
-            count: parts.length === 1 ? 0 : 1
-          };
-          lookup[firstPrefix].fullKey = fullKey;
-          if (parts.length === 1) {
-            lookup[firstPrefix].leaf = true;
-          }
-          reducedKeys.push(lookup[firstPrefix]);
-        }
+      reducedKeys = reducedKeys.sort(function (a, b) {
+        return a.data > b.data ? 1 : -1;
       });
-
-      reducedKeys.forEach(function (data) {
-        if (data.count === 0) {
-          data.data = data.attr.id;
-        } else {
-          data.data = data.attr.id + ":* (" + data.count + ")";
-          data.state = "closed";
-        }
-      });
-
-      async.forEachLimit(reducedKeys, 10, function (keyData, callback) {
-        if (keyData.leaf) {
-          redisConnection.type(keyData.fullKey, function (err, type) {
-            if (err) {
-              return callback(err);
-            }
-            keyData.attr.rel = type;
-            let sizeCallback = function (err, count) {
-              if (err) {
-                return callback(err);
-              } else {
-                keyData.data += " (" + count + ")";
-                callback();
-              }
-            };
-            if (type === 'list') {
-              redisConnection.llen(keyData.fullKey, sizeCallback);
-            } else if (type === 'set') {
-              redisConnection.scard(keyData.fullKey, sizeCallback);
-            } else if (type === 'zset') {
-              redisConnection.zcard(keyData.fullKey, sizeCallback);
-            } else {
-              callback();
-            }
-          });
-        } else {
-          callback();
-        }
-      }, function (err) {
-        if (err) {
-          console.error('getKeys', err);
-          return next(err);
-        }
-        reducedKeys = reducedKeys.sort(function (a, b) {
-          return a.data > b.data ? 1 : -1;
-        });
-        res.send(JSON.stringify(reducedKeys));
-      });
+      res.send(JSON.stringify(reducedKeys));
     });
   });
 }
 
 function postKeys (req, res, next) {
   let key = req.params.key;
-  let connectionId = req.params.connectionId;
-  getConnection(req.app.locals.redisConnections, connectionId, function (err, redisConnection) {
-    if (err || !redisConnection) return printError(res, next, err, 'postKeys');
-    if (req.query.action === 'delete') {
-      deleteKeys(key, redisConnection, res, next);
-    } else {
-      next(new Error("Invalid action '" + req.query.action + "'"));
-    }
-  });
+  if (req.query.action === 'delete') {
+    deleteKeys(key, res, next);
+  } else {
+    next(new Error("Invalid action '" + req.query.action + "'"));
+  }
 }
 
-function deleteKeys (keyQuery, redisConnection, res, next) {
+function deleteKeys (keyQuery, res, next) {
+  let redisConnection = res.locals.connection;
   redisConnection.keys(keyQuery, function (err, keys) {
     if (err) {
       console.error('deleteKeys', err);

--- a/lib/routes/apiv1.js
+++ b/lib/routes/apiv1.js
@@ -323,7 +323,7 @@ function postAddListValue (req, res, next) {
   let type = req.body.type;
   let connectionId = req.body.listConnectionId;
   getConnection(req, res, function () {
-    addListValue(res.locals.connection, key, value, type, res, next);
+    addListValue(key, value, type, res, next);
   }, connectionId);
 }
 
@@ -333,7 +333,7 @@ function postEditListRow (req, res, next) {
   let value = req.body.listValue;
   let connectionId = req.body.listConnectionId;
   getConnection(req, res, function () {
-    editListRow(redisConnection, key, index, value, res, next);
+    editListRow(key, index, value, res, next);
   }, connectionId);
 }
 
@@ -343,7 +343,7 @@ function postEditSetMember (req, res, next) {
   let oldMember = req.body.setOldMember;
   let connectionId = req.body.setConnectionId;
   getConnection(req, res, function () {
-    editSetMember(redisConnection, key, member, oldMember, res, next);
+    editSetMember(key, member, oldMember, res, next);
   }, connectionId);
 }
 
@@ -354,7 +354,7 @@ function postEditZSetRow (req, res, next) {
   let oldValue = req.body.zSetOldValue;
   let connectionId = req.body.zSetConnectionId;
   getConnection(req, res, function () {
-    editZSetRow(redisConnection, key, score, value, oldValue, res, next);
+    editZSetRow(key, score, value, oldValue, res, next);
   }, connectionId);
 }
 
@@ -364,7 +364,7 @@ function postEditHashRow (req, res, next) {
   let value = req.body.hashFieldValue;
   let connectionId = req.body.hashConnectionId;
   getConnection(req, res, function () {
-    editHashRow(redisConnection, key, field, value, res, next);
+    editHashRow(key, field, value, res, next);
   }, connectionId);
 }
 
@@ -373,11 +373,12 @@ function postAddSetMember (req, res, next) {
   let member = req.body.setMemberName;
   let connectionId = req.body.setConnectionId;
   getConnection(req, res, function() {
-    addSetMember(redisConnection, key, member, res, next);
+    addSetMember(key, member, res, next);
   }, connectionId);
 }
 
-function addSetMember (redisConnection, key, member, res, next) {
+function addSetMember (key, member, res, next) {
+  let redisConnection = res.locals.connection;
   myutil.decodeHTMLEntities(member, function (decodedString) {
     return redisConnection.sadd(key, decodedString, function (err) {
         if (err) {
@@ -389,8 +390,9 @@ function addSetMember (redisConnection, key, member, res, next) {
   });
 }
 
-function addSortedSetValue (redisConnection, key, score, value, res, next) {
-  return redisConnection.zadd(key, score, value, function (err) {
+function addSortedSetValue (key, score, value, res, next) {
+    let redisConnection = res.locals.connection;
+    return redisConnection.zadd(key, score, value, function (err) {
     if (err) {
       console.error('addZSetValue', err);
       return next(err);
@@ -399,7 +401,8 @@ function addSortedSetValue (redisConnection, key, score, value, res, next) {
   });
 }
 
-function addListValue (redisConnection, key, value, type, res, next) {
+function addListValue (key, value, type, res, next) {
+  let redisConnection = res.locals.connection;
   let callback = function (err) {
     if (err) {
       console.error('addListValue', err);
@@ -421,7 +424,8 @@ function addListValue (redisConnection, key, value, type, res, next) {
   });
 }
 
-function editListRow (redisConnection, key, index, value, res, next) {
+function editListRow (key, index, value, res, next) {
+  let redisConnection = res.locals.connection;
   myutil.decodeHTMLEntities(value, function (decodedString) {
     value = decodedString;
     redisConnection.lset(key, index, value, function (err) {
@@ -444,7 +448,8 @@ function editListRow (redisConnection, key, index, value, res, next) {
   });
 }
 
-function editSetMember (redisConnection, key, member, oldMember, res, next) {
+function editSetMember (key, member, oldMember, res, next) {
+  let redisConnection = res.locals.connection;
   myutil.decodeHTMLEntities(oldMember, function (decodedString) {
     oldMember = decodedString;
 
@@ -471,7 +476,8 @@ function editSetMember (redisConnection, key, member, oldMember, res, next) {
   });
 }
 
-function editZSetRow (redisConnection, key, score, value, oldValue, res, next) {
+function editZSetRow (key, score, value, oldValue, res, next) {
+  let redisConnection = res.locals.connection;
   myutil.decodeHTMLEntities(oldValue, function (decodedString) {
     oldValue = decodedString;
 
@@ -498,7 +504,8 @@ function editZSetRow (redisConnection, key, score, value, oldValue, res, next) {
   });
 }
 
-function editHashRow (redisConnection, key, field, value, res, next) {
+function editHashRow (key, field, value, res, next) {
+  let redisConnection = res.locals.connection;
   myutil.decodeHTMLEntities(field, function (decodedField) {
     myutil.decodeHTMLEntities(value, function (decodedValue) {
       if (value === "REDISCOMMANDERTOMBSTONE") {
@@ -550,13 +557,13 @@ function saveKey (req, res, next) {
       switch (type) {
           case 'string':
           case 'none':
-              return posKeyDetailsString(redisConnection, key, value, req, res, next);
+              return posKeyDetailsString(key, value, req, res, next);
           case 'list':
-              return addListValue(redisConnection, key, value, 'lpush', res, next);
+              return addListValue(key, value, 'lpush', res, next);
           case 'set':
-              return addSetMember(redisConnection, key, value, res, next);
+              return addSetMember(key, value, res, next);
           case 'zset':
-              return addSortedSetValue(redisConnection, key, score, value, res, next);
+              return addSortedSetValue(key, score, value, res, next);
           default:
               return next(new Error("Unhandled type " + type));
       }
@@ -617,8 +624,9 @@ function deleteKey (req, res, next) {
   });
 }
 
-function posKeyDetailsString (redisConnection, key, value, req, res, next) {
+function posKeyDetailsString (key, value, req, res, next) {
   if (!req.app.locals.noLogData) console.log("new value for key: ", value);
+  let redisConnection = res.locals.connection;
   redisConnection.set(key, value, function (err) {
     if (err) {
       console.error('posKeyDetailsString', err);

--- a/lib/routes/apiv1.js
+++ b/lib/routes/apiv1.js
@@ -73,7 +73,7 @@ function getConnection (req, res, next, connectionId) {
   }
   else {
     console.error('Connection with id ' + connectionId + ' not found.');
-    printError(res, next, null, req.originalUrl);
+    return printError(res, next, null, req.originalUrl);
   }
   next();
 }

--- a/web/static/scripts/redisCommander.js
+++ b/web/static/scripts/redisCommander.js
@@ -109,13 +109,13 @@ function loadTree () {
                   }
                 };
                 var rel = node.attr('rel');
-                if (rel != undefined && rel != 'root') {
+                if (typeof rel !== 'undefined' && rel !== 'root') {
                   delete menu['addKey'];
                 }
-                if (rel != 'root') {
+                if (rel !== 'root') {
                   delete menu['remConnection'];
                 }
-                if (rel == 'root') {
+                if (rel === 'root') {
                   delete menu['remKey'];
                 }
                 return menu;
@@ -142,7 +142,7 @@ function treeNodeSelected (event, data) {
   if (pathParts.length === 1) {
     var hostAndPort = pathParts[0].split(':');
     $.get('apiv1/server/info', function (data, status) {
-      if (status != 'success') {
+      if (status !== 'success') {
         return alert("Could not load server info");
       }
       data = JSON.parse(data);
@@ -170,12 +170,12 @@ function getRootConnection (node) {
 
 function loadKey (connectionId, key, index) {
   if (index) {
-    $.get('apiv1/key/' + encodeURIComponent(connectionId) + "/" + encodeURIComponent(key) + "/" + index, processData);
+    $.get('apiv1/key/' + encodeURIComponent(connectionId) + "/" + encodeURIComponent(key) + "?index=" + index, processData);
   } else {
     $.get('apiv1/key/' + encodeURIComponent(connectionId) + "/" + encodeURIComponent(key), processData);
   }
   function processData (data, status) {
-    if (status != 'success') {
+    if (status !== 'success') {
       return alert("Could not load key data");
     }
 
@@ -300,7 +300,7 @@ function setupAddKeyButton (connectionId) {
   });
   $('#keyType').change(function () {
     var score = $('#scoreWrap');
-    if ($(this).val() == 'zset') {
+    if ($(this).val() === 'zset') {
       score.show();
     } else {
       score.hide();
@@ -309,8 +309,7 @@ function setupAddKeyButton (connectionId) {
   $('#addKeyForm').ajaxForm({
     beforeSubmit: function () {
       console.log('saving');
-      $('#saveKeyButton').attr("disabled", "disabled");
-      $('#saveKeyButton').html("<i class='icon-refresh'></i> Saving");
+      $('#saveKeyButton').attr("disabled", "disabled").html("<i class='icon-refresh'></i> Saving");
     },
     error: function (err) {
       console.log('save error', arguments);
@@ -325,8 +324,7 @@ function setupAddKeyButton (connectionId) {
 
   function saveComplete () {
     setTimeout(function () {
-      $('#saveKeyButton').html("Save");
-      $('#saveKeyButton').removeAttr("disabled");
+      $('#saveKeyButton').removeAttr("disabled").html("Save");
       refreshTree();
       $('#addKeyModal').modal('hide');
     }, 500);
@@ -392,8 +390,7 @@ function selectTreeNodeString (data) {
   $('#editStringForm').ajaxForm({
     beforeSubmit: function () {
       console.log('saving');
-      $('#saveKeyButton').attr("disabled", "disabled");
-      $('#saveKeyButton').html("<i class='icon-refresh'></i> Saving");
+      $('#saveKeyButton').attr("disabled", "disabled").html("<i class='icon-refresh'></i> Saving");
     },
     error: function (err) {
       console.log('save error', arguments);
@@ -410,8 +407,7 @@ function selectTreeNodeString (data) {
 
   function saveComplete () {
     setTimeout(function () {
-      $('#saveKeyButton').html("Save");
-      $('#saveKeyButton').removeAttr("disabled");
+      $('#saveKeyButton').removeAttr("disabled").html("Save");
     }, 500);
   }
 }
@@ -497,7 +493,7 @@ function refreshTree () {
 }
 
 function addKey (connectionId, key) {
-  if (typeof(connectionId) == 'object') {
+  if (typeof(connectionId) === 'object') {
     key = getFullKeyPath(connectionId);
     if (key.length > 0) {
       key = key + ":";
@@ -511,7 +507,7 @@ function addKey (connectionId, key) {
   setupAddKeyButton(connectionId);
 }
 function deleteKey (connectionId, key) {
-  if (typeof(connectionId) == 'object') {
+  if (typeof(connectionId) === 'object') {
     key = getFullKeyPath(connectionId);
     var pathParts = getKeyTree().get_path(connectionId, true);
     connectionId = pathParts.slice(0, 1)[0];
@@ -519,7 +515,7 @@ function deleteKey (connectionId, key) {
   var result = confirm('Are you sure you want to delete "' + key + ' from ' + connectionId + '"?');
   if (result) {
     $.post('apiv1/key/' + encodeURIComponent(connectionId) + '/' + encodeURIComponent(key) + '?action=delete', function (data, status) {
-      if (status != 'success') {
+      if (status !== 'success') {
         return alert("Could not delete key");
       }
 
@@ -531,14 +527,14 @@ function deleteKey (connectionId, key) {
 }
 
 function decodeKey (connectionId, key) {
-  if (typeof(connectionId) == 'object') {
+  if (typeof(connectionId) === 'object') {
     key = getFullKeyPath(connectionId);
     var pathParts = getKeyTree().get_path(connectionId, true);
     connectionId = pathParts.slice(0, 1)[0];
   }
 
   $.post('apiv1/key/' + encodeURIComponent(connectionId) + '/' + encodeURIComponent(key) + '?action=decode', function (data, status) {
-    if (status != 'success') {
+    if (status !== 'success') {
       return alert("Could not decode key");
     }
 
@@ -553,7 +549,7 @@ function decodeKey (connectionId, key) {
 
 function encodeString (connectionId, key) {
   $.post('apiv1/encodeString/' + encodeURIComponent($('#stringValue').val()), function (data, status) {
-    if (status != 'success') {
+    if (status !== 'success') {
       return alert("Could not encode key");
     }
 
@@ -574,7 +570,7 @@ function deleteBranch (connectionId, branchPrefix) {
   var result = confirm('Are you sure you want to delete "' + query + ' from ' + connectionId + '"? This will delete all children as well!');
   if (result) {
     $.post('apiv1/keys/' + encodeURIComponent(connectionId) + "/" + encodeURIComponent(query) + '?action=delete', function (data, status) {
-      if (status != 'success') {
+      if (status !== 'success') {
         return alert("Could not delete branch");
       }
 
@@ -715,7 +711,7 @@ function loadCommandLine () {
       $.post('apiv1/exec', { cmd: line, connection: $('#selectedConnection').val() }, function (data, status) {
         rl.prompt();
 
-        if (status != 'success') {
+        if (status !== 'success') {
           return alert("Could not delete branch");
         }
 
@@ -900,7 +896,7 @@ var cmdparser = new CmdParser([
   key: function (partial, callback) {
     var redisConnection = $('#selectedConnection').val();
     $.get('apiv1/keys/' + encodeURIComponent(redisConnection) + "/" + partial + '*?limit=20', function (data, status) {
-      if (status != 'success') {
+      if (status !== 'success') {
         return callback(new Error("Could not get keys"));
       }
       data = JSON.parse(data)
@@ -925,14 +921,14 @@ function getServerInfo (callback) {
 }
 
 function removeServer (connectionId) {
-  if (typeof(connectionId) == 'object') {
+  if (typeof(connectionId) === 'object') {
     var pathParts = getKeyTree().get_path(connectionId, true);
     connectionId = pathParts.slice(0, 1)[0];
   }
   var result = confirm('Are you sure you want to disconnect from "' + connectionId + '"?');
   if (result) {
     $.post('logout/' + encodeURIComponent(connectionId), function (err, status) {
-      if (status != 'success') {
+      if (status !== 'success') {
         return alert("Could not remove instance");
       }
       $(window).unbind('beforeunload'); // not sure if necessary
@@ -959,7 +955,7 @@ function configChange () {
     var locked = !$('#lockCommandButton').hasClass('disabled');
     var CLIWidth = $('#commandLineContainer').height();
 
-    if (typeof(prevSidebarWidth) != 'undefined' &&
+    if (typeof(prevSidebarWidth) !== 'undefined' &&
       (sidebarWidth != prevSidebarWidth ||
         locked != prevLocked ||
         CLIWidth != prevCLIWidth ||
@@ -989,7 +985,7 @@ function saveConfig () {
       $.post('config', config, function (data, status) {
       });
     } else {
-      var config = {
+      config = {
         "sidebarWidth": sidebarWidth,
         "locked": locked,
         "CLIHeight": CLIHeight,
@@ -1032,8 +1028,7 @@ function resizeApp () {
   $('#sideBar').css('width', barWidth);
   var bodyMargin = parseInt($('#body').css('margin-left'), 10);
   var newBodyWidth = $(window).width() - barWidth - bodyMargin;
-  $('#body,#itemActionsBar').css('width', newBodyWidth);
-  $('#body,#itemActionsBar').css('left', barWidth);
+  $('#body,#itemActionsBar').css('width', newBodyWidth).css('left', barWidth);
 
   $('#keyTree').height($(window).height() - $('#keyTree').offset().top - $('#commandLineContainer').outerHeight(true));
   $('#body, #sidebarResize').css('height', $('#sideBar').css('height'));
@@ -1090,18 +1085,18 @@ function setupCLIKeyEvents () {
   cli.live('keydown', function (e) {
     var key = e.which;
     //ctrl
-    if (key == 17 && isMac) {
+    if (key === 17 && isMac) {
       ctrl_down = true;
     }
 
     //c
-    if (key == 67 && ctrl_down) {
+    if (key === 67 && ctrl_down) {
       clearCLI();
       e.preventDefault();
     }
 
     //esc
-    if (key == 27) {
+    if (key === 27) {
       clearCLI();
       e.preventDefault();
     }
@@ -1109,7 +1104,7 @@ function setupCLIKeyEvents () {
   cli.live('keyup', function (e) {
     var key = e.which;
     //ctrl
-    if (key == 17 && isMac) {
+    if (key === 17 && isMac) {
       ctrl_down = false;
     }
   });
@@ -1127,7 +1122,7 @@ function setupCLIKeyEvents () {
 $(function() {
   function refreshQueryToken() {
     $.post('signin', {}, function (data, status) {
-      if ((status != 'success') || !data || !data.ok) {
+      if ((status !== 'success') || !data || !data.ok) {
         console.error("Cannot refresh query token");
         return;
       }

--- a/web/static/scripts/redisCommander.js
+++ b/web/static/scripts/redisCommander.js
@@ -1,5 +1,4 @@
 'use strict';
-var foldingCharacter = ":";
 
 var CmdParser = require('cmdparser');
 function loadTree () {

--- a/web/views/home/home.ejs
+++ b/web/views/home/home.ejs
@@ -57,15 +57,15 @@
   <div class="modal-body">
     <div class="container" id="addServerContainer">
       <form action="login" method="POST" id="addServerForm">
-        <label>Name</label>
+        <label for="label">Name</label>
         <input type="text" name="label" id="label" value="">
-        <label>Hostname</label>
+        <label for="hostname">Hostname</label>
         <input type="text" name="hostname" id="hostname" value="localhost">
-        <label>Port or Unix Socket Path</label>
+        <label for="port">Port or Unix Socket Path</label>
         <input type="text" name="port" id="port" value="6379">
-        <label>Password</label>
+        <label for="password">Password</label>
         <input type="password" name="password" id="password" value="">
-        <label>Database Index</label>
+        <label for="dbIndex">Database Index</label>
         <input type="number" name="dbIndex" id="dbIndex" value="0">
         <br>
       </form>
@@ -79,6 +79,7 @@
 <!-- /COMMANDS MODAL -->
 
 <script type="text/javascript">
+  var foldingCharacter = '<%= foldingCharacter %>';
   var setConnection = function (connectionId) {
     $('#selectedConnectionLabel').text("Current Instance: " + connectionId);
     $('#selectedConnection').val(connectionId);
@@ -97,7 +98,7 @@
     });
     function refreshToken() {
       $.post('signin', {}, function (data, status) {
-        if (status != 'success') {
+        if (status !== 'success') {
           console.error("refresh token connection problem");
           return;
         }
@@ -148,7 +149,7 @@
         $('.container').removeClass('container');
         $('html').css('overflow-y', 'hidden');
         $('#pageIndex').live('keydown', function (e) {
-          if (e.keyCode == 13) {
+          if (e.keyCode === 13) {
             $('#gotoIndexButton').click();
           }
         });
@@ -162,7 +163,5 @@
     .fail(err => {
       console.error("Failed to fetch connections", err);
     });
-    
-    
   });
 </script>

--- a/web/views/layout.ejs
+++ b/web/views/layout.ejs
@@ -2,7 +2,7 @@
 <html>
 <head>
   <title>Redis Commander: <%= title %></title>
-  <link rel="icon" 
+  <link rel="icon"
       href="favicon.png">
   <link href="bootstrap/css/bootstrap.css" rel="stylesheet"/>
   <style type="text/css">


### PR DESCRIPTION
This update allows setting the folding character to something different from the default ':'

For example - setting the char to '/' via command line or environment var correctly folds the tree view for keys like "abc/def/ghi" as up to now is only done for "abc:def:ghi" with hardcoded ":".

It is only possible to define one common folding character used for all redis connections.

Allowing '/' as redis key separator needed some rework of the apiv1 file to use the new router object of express 4.x to not interfere with / as url param separator. Doing this the "index" url param of the /apiv1/key/:connection/:key/:index? route was reassigned as query parameter.