### PR TITLE
Fix data import for strings with spaces

### DIFF
--- a/docker/redis-dump.diff
+++ b/docker/redis-dump.diff
@@ -1,12 +1,71 @@
 diff -ur node_modules/node-redis-dump/lib/node-redis-dump.js node_modules_save/node-redis-dump/lib/node-redis-dump.js
---- node_modules/node-redis-dump/lib/node-redis-dump.js	2018-07-24 17:48:39.774935081 +0200
-+++ node_modules_save/node-redis-dump/lib/node-redis-dump.js	2018-07-24 17:45:50.811077357 +0200
-@@ -417,7 +417,7 @@
+--- node_modules/node-redis-dump/lib/node-redis-dump.js	2018-08-29 13:24:53.763884645 +0200
++++ node_modules_save/node-redis-dump/lib/node-redis-dump.js	2018-08-29 13:03:26.718613348 +0200
+@@ -391,33 +391,43 @@
+ 					command = items.pop(),
+ 					callArgs = [];
+
+-				switch (command) {
+-					case 'SET':
+-					case 'SADD':
+-						callArgs = args.match(new RegExp('"?(.+?)"?\\s+"?(.+?)"?(?:\\s|$)', 'i')).slice(1, 3);
+-						break;
+-
+-					case 'RPUSH':
+-					case 'LPUSH':
+-						callArgs = args.match(new RegExp('"?(.+?)"?\\s+"?([0-9]+?)"?(?:\\s|$)', 'i')).slice(1, 3);
+-						break;
+-
+-					case 'ZADD':
+-						callArgs = args.match(new RegExp('"?(.+?)"?\\s+"?([0-9]+?)"?\\s+"?(.+?)"?(\\s|$)', 'i')).slice(1, 4);
+-						break;
+-
+-					case 'HSET':
+-						callArgs = args.match(new RegExp('"?(.+?)"?\\s+"?(.+?)"?\\s+"?(.+?)"?(\\s|$)', 'i')).slice(1, 4);
+-						break;
+-
+-					default:
+-						console.error(command, args);
+-						callback('Error import data! Not supported type!');
+-						return;
++				try {
++                    switch (command) {
++                        case 'SET':
++                        case 'SADD':
++                        case 'LPUSH':
++                        case 'LPUSHX':
++                        case 'RPUSH':
++                        case 'RPUSHX':
++                            // only simple form with one value is allowed, no options (EX, NX, ...)
++                            callArgs = args.match(new RegExp('"?(.+?)"?\\s+(["\'](.+?)["\']|(.+?))(?:\\s|$)', 'i')).slice(1, 3);
++                            callArgs[1] = callArgs[1].replace(/(^["']|["']$)/g, '');   // remove optional quotes around value string
++                            break;
++
++                        case 'ZADD':
++                        case 'LSET':
++                        	// only simple form with one value: "ZADD key 1 value", no options (NX, XX, ...)
++                            callArgs = args.match(new RegExp('"?(.+?)"?\\s+"?([0-9]+?)"?\\s+(["\'](.+?)["\']|(.+?))(\\s|$)', 'i')).slice(1, 4);
++                            callArgs[2] = callArgs[2].replace(/(^["']|["']$)/g, '');   // remove optional quotes around value string
++                            break;
++
++                        case 'HSET':
++                            callArgs = args.match(new RegExp('"?(.+?)"?\\s+"?(.+?)"?\\s+(["\'](.+?)["\']|(.+?))(\\s|$)', 'i')).slice(1, 4);
++                            callArgs[2] = callArgs[2].replace(/(^["']|["']$)/g, '');   // remove optional quotes around value string
++                            break;
++
++                        default:
++                            console.error(command, args);
++                            callback('Error import data! Not supported type!');
++                            return;
++                    }
++                }
++                catch (errCmd) {
++					callback('FAIL parse command of known type');
  				}
- 
+
  				callArgs.push(Callback);
 -				this.getClient()[ command ].apply(this.getClient(), callArgs);
 +				this.getClient()[ command.toLowerCase() ].apply(this.getClient(), callArgs);
  			}.bind(this);
- 
+
  			AddRecursive();

--- a/lib/routes/tools.js
+++ b/lib/routes/tools.js
@@ -64,20 +64,26 @@ module.exports = function (app, urlPrefix) {
    */
   app.post(`${urlPrefix}/tools/import`, _findConnection, function (req, res) {
     let dump = new RedisDump({client: req.redisClient});
-    dump.import({
-      type: 'redis',
-      data: req.body.data,
-      clear: req.body.clear,
-      callback: function(err, report) {
-        report.status = 'OK';
-        if (err) {
-          report.status = 'FAIL';
-          console.error('Could\'t not import redis data!', err);
-        }
+    try {
+        dump.import({
+            type: 'redis',
+            data: req.body.data,
+            clear: req.body.clear,
+            callback: function(err, report) {
+                report.status = 'OK';
+                if (err) {
+                    report.status = 'FAIL';
+                    console.error('Could\'t not import redis data!', err);
+                }
 
-        res.end(JSON.stringify(report));
-      }
-    });
+                res.end(JSON.stringify(report));
+            }
+        });
+    }
+    catch(e) {
+        console.error('Could\'t not import redis data! Exception:', e);
+        res.json({inserted: 0, errors: -1, status: 'FAIL', message: 'Exception processing inport data'});
+    }
   });
 
   /**

--- a/web/views/tools/importData.ejs
+++ b/web/views/tools/importData.ejs
@@ -21,8 +21,10 @@
             SET<br/>
             HSET<br/>
             LPUSH<br/>
+            LPUSHX<br/>
             RPUSH<br/>
-            <!--LSET<br/>-->
+            RPUSHX<br/>
+            LSET<br/>
             SADD<br/>
             ZADD
         </span>


### PR DESCRIPTION
The import works only partially as of today. Some commands are broken in the currently used library and all commands do not allow strings with spaces as values. For them the first word is imported only.

As this library seems to be dead (last contribution of EvilDevRu is in January 2016) i updated the diff file already included and used during docker image build. Started pull request there too (https://github.com/EvilDevRu/node-redis-dump/pull/2)

For longer/better maintenance the question is if this library should be forked or replaced with someething else?

Pull request items done:
* fix quoted string values with spaces for all redis commands on import (e.g. SET mykey "Hello world")
* fix broken LPUSH, RPUSH
* add new commands LPUSHX, RPUSHX, LSET to import as they use the same arguments as already implemented ones
* add information about new supported commands to UI
* make import more robust against errors