### PR TITLE
Do not remove apk as default during docker build process

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,6 +1,12 @@
 FROM node:8-alpine
 
 WORKDIR /redis-commander
+
+# optional build arg to let the hardening process revomve the apk too to not allow installation
+# of packages anymore, default: do not remove "apk" to allow others to use this as a base image
+# for own images
+ARG REMOVE_APK=0
+
 ENV SERVICE_USER=redis
 ENV HOME=/redis-commander
 ENV NODE_ENV=production

--- a/README.md
+++ b/README.md
@@ -159,3 +159,9 @@ containers:
   - name: redis-commander
     containerPort: 8081
 ```
+
+## Build images based on this one
+
+To use this images as a base image for other images you need to call "apk update" inside your Dockerfile
+before adding other apk packages with "apk add foo". Afterwards, to reduce your image size, you may
+remove all temporary apk configs too again as this Dockerfile does.

--- a/docker/harden.sh
+++ b/docker/harden.sh
@@ -2,7 +2,7 @@
 set -x
 set -e
 
-# this script is taken from 
+# this script is taken from
 # https://github.com/ellerbrock/docker-collection/tree/master/dockerfiles/alpine-harden
 
 # Be informative after successful login.
@@ -28,11 +28,15 @@ rm -fr /etc/crontabs
 rm -fr /etc/periodic
 
 # Remove all but a handful of admin commands.
+if [ "$REMOVE_APK" = "0" ]; then
+    APK_CMD="-a ! -name apk"
+fi
 find /sbin /usr/sbin ! -type d \
   -a ! -name login_duo \
   -a ! -name setup-proxy \
   -a ! -name sshd \
   -a ! -name start.sh \
+  ${APK_CMD} \
   -delete
 
 # Remove world-writable permissions.
@@ -57,7 +61,9 @@ sysdirs="
 "
 
 # Remove apk configs.
-find $sysdirs -xdev -regex '.*apk.*' -exec rm -fr {} +
+if [ "$REMOVE_APK" != "0" ]; then
+    find $sysdirs -xdev -regex '.*apk.*' -exec rm -fr {} +
+fi
 
 # Remove crufty...
 #   /etc/shadow-


### PR DESCRIPTION
As some other people seem to use this image as a base for their own images they need the apk tool for easy software installation (e.g. #279). This PR does not remove "apk" as Default anymore during hardening.

Building this image for yourself, apk can be removed with optional build arg REMOVE_APK=1