### PR TITLE
make shure all jstree nodes get unique id accross all connections

### DIFF
--- a/lib/routes/apiv1.js
+++ b/lib/routes/apiv1.js
@@ -703,11 +703,21 @@ function getKeysTree (req, res, next) {
       if (lookup.hasOwnProperty(firstPrefix)) {
         lookup[firstPrefix].count++;
       } else {
+        // must provide unique id over all connections for jstree to work correctly
+        let nodeId = '';
+        if (prefix) {
+          nodeId = res.locals.connectionId + ":" + prefix + foldingCharacter + firstPrefix;
+        }
+        else {
+          nodeId = res.locals.connectionId + ":" + firstPrefix;
+        }
         lookup[firstPrefix] = {
-          id: firstPrefix,
-          count: parts.length === 1 ? 0 : 1
+          id: nodeId,
+          text: firstPrefix,
+          count: parts.length === 1 ? 0 : 1,
+          keyName: firstPrefix,
+          fullKey: fullKey
         };
-        lookup[firstPrefix].fullKey = fullKey;
         if (parts.length !== 1) {
           lookup[firstPrefix].children = true;
         }
@@ -716,10 +726,8 @@ function getKeysTree (req, res, next) {
     });
 
     reducedKeys.forEach(function (data) {
-      if (data.count === 0) {
-        data.text = data.id;
-      } else {
-        data.text = data.id + foldingCharacter + '* (' + data.count + ')';
+      if (data.count !== 0) {
+        data.text = data.text + foldingCharacter + '* (' + data.count + ')';
         data.state = {
           opened: false
         };
@@ -738,6 +746,7 @@ function getKeysTree (req, res, next) {
               return callback(err);
             } else {
               keyData.text += " (" + count + ")";
+              delete keyData.fullKey;
               callback();
             }
           };
@@ -748,10 +757,12 @@ function getKeysTree (req, res, next) {
           } else if (type === 'zset') {
             redisConnection.zcard(keyData.fullKey, sizeCallback);
           } else {
+            delete keyData.fullKey;
             callback();
           }
         });
       } else {
+        delete keyData.fullKey;
         callback();
       }
     }, function (err) {

--- a/web/static/scripts/redisCommander.js
+++ b/web/static/scripts/redisCommander.js
@@ -163,9 +163,7 @@ function getFullKeyPath (node) {
   if (node.parent === '#') {
       return '';
   }
-  var keyList = node.parents.slice(0,-2).reverse();
-  keyList.push(node.id);
-  return keyList.join(foldingCharacter);
+  return node.id.substr(getRootConnection(node).length + 1);
 }
 
 function getRootConnection (node) {


### PR DESCRIPTION
JSTree displays data at wrong place inside the tree if multiple "folders" has the same id (=folder name).
This PR creates unique ids for all folders and items across all connections to fix this problem.
