### PR TITLE
Quotes for port mapping in docker-compose

### DIFF
--- a/README.md
+++ b/README.md
@@ -107,7 +107,7 @@ services:
     environment:
     - REDIS_HOSTS=local:redis:6379
     ports:
-    - 8081:8081
+    - "8081:8081"
 ```
 
 ### Without docker-compose

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -14,4 +14,4 @@ services:
     environment:
     - REDIS_HOSTS=local:redis:6379
     ports:
-    - 8081:8081
+    - "8081:8081"


### PR DESCRIPTION
### What's the issue?
According to docker-compose's [reference](https://docs.docker.com/compose/compose-file/#short-syntax-1), port mappings on docker-compose.yml should be surrounded by quotes `" "` to avoid YAML parse errors in case somebody wants to use a port lower than 60.

### What did I do?
I changed the README.md and docker-compose.yml by adding quotes when necessary.

### Extra
I don't know if the case is the same for Kubernetes's YAML so I didn't mess with it.