### PR TITLE
Bugfixes for large Redis DBs, Openshift and Browserify

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -16,13 +16,16 @@ ENV NODE_ENV=production
 COPY . .
 COPY docker/redis-commander.json .redis_commander
 
+# for Openshift compatibility set project dir itself group root and make it group writeable
 RUN  apk update \
   && apk upgrade \
   && apk add --no-cache ca-certificates dumb-init \
   && apk add --no-cache --virtual .patch-dep patch \
   && update-ca-certificates \
   && adduser ${SERVICE_USER} -h ${HOME} -S \
-  && chown -R ${SERVICE_USER} ${HOME} \
+  && chown -R root.root ${HOME} \
+  && chmod g+w ${HOME} \
+  && chown ${SERVICE_USER} ${HOME} \
   && npm install --production -s \
   && patch -p0 < docker/redis-dump.diff \
   && apk del .patch-dep \

--- a/lib/app.js
+++ b/lib/app.js
@@ -67,7 +67,7 @@ function jwtVerify(jwtSecret, token) {
   })
 }
 
-// process.chdir( path.join(__dirname, '..') );    // fix the cwd
+process.chdir( path.join(__dirname, '..') );    // fix the cwd to project base dir for browserify
 
 let viewsPath = path.join(__dirname, '../web/views');
 let staticPath = path.join(__dirname, '../web/static');

--- a/lib/routes/apiv1.js
+++ b/lib/routes/apiv1.js
@@ -962,7 +962,7 @@ function getKeysTree (req, res, next) {
         });
       } else {
         delete keyData.fullKey;
-        callback();
+        async.setImmediate(callback);
       }
     }, function (err) {
       if (err) {


### PR DESCRIPTION
* Fix Bug #182 with large call stacks
* make browserify work gain for some people #182 #314 #232 (hopefully)
* modify automatically build dockerhub image to work in Openshift without need to build again via source-2-image #311 