### PR TITLE
Fix docker-compose.yml File on README file

### DIFF
--- a/README.md
+++ b/README.md
@@ -104,7 +104,6 @@ services:
     container_name: redis-commander
     hostname: redis-commander
     image: rediscommander/redis-commander:latest
-    build: .
     restart: always
     environment:
     - REDIS_HOSTS=local:redis:6379


### PR DESCRIPTION
Since the Image already specified on the `docker-compose.yml` file, there is no need to add `build` or error may happen
```
root@docker:~# docker-compose up -d

Creating network "root_default" with the default driver
Pulling redis (redis:)...
latest: Pulling from library/redis
a5a6f2f73cd8: Pull complete
a6d0f7688756: Pull complete
53e16f6135a5: Pull complete
f52b0cc4e76a: Pull complete
e841feee049e: Pull complete
ccf45e5191d0: Pull complete
Digest: sha256:010a8bd5c6a9d469441aa35187d18c181e3195368bce309348b3ee639fce96e0
Status: Downloaded newer image for redis:latest
Building redis-commander
ERROR: Cannot locate specified Dockerfile: Dockerfile
```