### PR TITLE
Fix an Uncaught SyntaxError on Chrome

### DIFF
--- a/web/static/scripts/redisCommander.js
+++ b/web/static/scripts/redisCommander.js
@@ -765,7 +765,9 @@ function enableJsonValidationCheck(value, isJsonCheckBox) {
       $(isJsonCheckBox).click();
     }
   }
-  catch {}
+  catch (ex) {
+    // do nothing
+  }
 }
 
 function removeListElement () {


### PR DESCRIPTION
Without this, my Chrome(Version 64.0.3282.140) will show an error:

`Uncaught SyntaxError: Unexpected token {`

and then the whole page will not load correctly