### PR TITLE
Allow specifying a Redis Sentinel group name

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,6 +26,7 @@ Options:
   --redis-label                        The label to display for the connection. [string]
   --sentinel-port                      The port to find redis sentinel on.      [string]
   --sentinel-host                      The host to find redis sentinel on.      [string]
+  --sentinel-name                      The redis sentinel group name to use.    [string]  [default: mymaster]
   --http-auth-username, --http-u       The http authorisation username.         [string]
   --http-auth-password, --http-p       The http authorisation password.         [string]
   --http-auth-password-hash, --http-h  The http authorisation password hash.    [string]
@@ -124,6 +125,7 @@ REDIS_DB
 REDIS_HOSTS
 SENTINEL_PORT
 SENTINEL_HOST
+SENTINEL_NAME
 K8S_SIGTERM
 ```
 

--- a/bin/redis-commander.js
+++ b/bin/redis-commander.js
@@ -22,17 +22,9 @@ let args = optimist
     string: true,
     describe: 'The port to find redis on.'
   })
-  .options('sentinel-port', {
-    string: true,
-    describe: 'The port to find sentinel on.'
-  })
   .options('redis-host', {
     string: true,
     describe: 'The host to find redis on.'
-  })
-  .options('sentinel-host', {
-    string: true,
-    describe: 'The host to find sentinel on.'
   })
   .options('redis-socket', {
     string: true,
@@ -53,6 +45,10 @@ let args = optimist
   .options('sentinel-host', {
     string: true,
     describe: 'The host to find sentinel on.'
+  })
+  .options('sentinel-name', {
+    string: true,
+    describe: 'The sentinel group name to use.'
   })
   .options('redis-tls', {
     boolean: true,
@@ -359,6 +355,7 @@ function startAllConnections() {
         newDefault.host = args['redis-host'] || "localhost";
         newDefault.sentinel_host = args['sentinel-host'];
         newDefault.sentinel_port = args['sentinel-port'];
+        newDefault.sentinel_name = args['sentinel-name'];
         newDefault.port = args['redis-port'] || "6379";
       }
 

--- a/docker/entrypoint.sh
+++ b/docker/entrypoint.sh
@@ -183,6 +183,10 @@ fi
 if [[ ! -z "$SENTINEL_HOST" ]]; then
     set -- "$@" "--sentinel-host $SENTINEL_HOST"
 fi
+
+if [[ ! -z "$SENTINEL_NAME" ]]; then
+    set -- "$@" "--sentinel-name $SENTINEL_NAME"
+fi
 # all other env vars are evaluated by node-config module ...
 
 


### PR DESCRIPTION
This change allows the user to specify a Redis Sentinel group name other than the default "mymaster". I've updated the CLI and Docker accordingly, and also removed duplicated options for sentinel-port and sentinel-host.