### PR TITLE
Using `node:8` instead of `node:8-alpine`

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM node:8-alpine
+FROM node:8
 
 WORKDIR /redis-commander
 


### PR DESCRIPTION
Hi @joeferner 
Thank you for the work you put on `redis-commander`. It is really UI for redis.

I would like to propose using `node:8` Docker instead of `FROM node:8-alpine`.
I know the alpine image is smaller, but the `ash` shell that comes with Alpine does not provide a great support for shell script (for example: we can not declare array with `typeset`).