### PR TITLE
Update redis-commander.js

### DIFF
--- a/bin/redis-commander.js
+++ b/bin/redis-commander.js
@@ -501,7 +501,7 @@ function startWebApp () {
   let appInstance = app(redisConnections);
 
   appInstance.listen(config.get('server.port'), config.get('server.address'), function() {
-    console.log("listening on ", config.get('server.address'), ":", config.get('server.port'));
+    console.log("listening on", "http://" + config.get('server.address') + ":" + config.get('server.port'));
     if (urlPrefix) {
       console.log(`using url prefix ${urlPrefix}/`);
     }


### PR DESCRIPTION
Print valid http address on startup, to be able just copy and past it to browser.
Some terminals even can make such links clickable (iTerm2 for example)