### PR TITLE
fix link overlap in commands popup

### DIFF
--- a/web/static/css/default.css
+++ b/web/static/css/default.css
@@ -243,7 +243,7 @@ body {
   opacity: 0.2;
   position: absolute;
   top: 14px;
-  left: 150px;
+  left: 350px;
   z-index: 99999;
 }
 


### PR DESCRIPTION
The `open in new window`  is overlapping with the redis icon as well as the close icon, as show below:
![Screen Shot 2019-07-26 at 11 20 17 AM](https://user-images.githubusercontent.com/2096033/61962790-57890c80-af98-11e9-9261-a908675b4883.png)
![Screen Shot 2019-07-26 at 11 20 25 AM](https://user-images.githubusercontent.com/2096033/61962791-5821a300-af98-11e9-92a6-1e1799b6ca3e.png)


**After fix:**


![Screen Shot 2019-07-26 at 11 20 06 AM](https://user-images.githubusercontent.com/2096033/61962812-65d72880-af98-11e9-86ed-ad258b35d8b8.png)
![Screen Shot 2019-07-26 at 11 19 58 AM](https://user-images.githubusercontent.com/2096033/61962813-65d72880-af98-11e9-8353-ade41ef3f80b.png)

