### PR TITLE
Make compatible with windows paths

### DIFF
--- a/lib/app.js
+++ b/lib/app.js
@@ -83,7 +83,7 @@ let redisConnections = [];
 let viewsPath = path.join(__dirname, '../web/views');
 let staticPath = path.join(__dirname, '../web/static');
 let modulesPath = function(module) {
-  return require.resolve(module, {paths: __dirname}).replace(/\\/g, '/').match(/.*\/node_modules\/[^/]+\//)[0]
+  return require.resolve(module).replace(/\\/g, '/').match(/.*\/node_modules\/[^/]+\//)[0]
 };
 
 module.exports = function (_redisConnections) {

--- a/lib/app.js
+++ b/lib/app.js
@@ -83,7 +83,7 @@ let redisConnections = [];
 let viewsPath = path.join(__dirname, '../web/views');
 let staticPath = path.join(__dirname, '../web/static');
 let modulesPath = function(module) {
-  return require.resolve(module).match(/.*\/node_modules\/[^/]+\//)[0];
+  return require.resolve(module, {paths: __dirname}).replace(/\\/g, '/').match(/.*\/node_modules\/[^/]+\//)[0]
 };
 
 module.exports = function (_redisConnections) {


### PR DESCRIPTION
The current implemention leads to errors in windows devices due to windows paths using backslashes instead of slashes. This fixes this.