### PR TITLE
Adding maxHashFieldSize config to limit the size of hash fields

### DIFF
--- a/bin/redis-commander.js
+++ b/bin/redis-commander.js
@@ -147,6 +147,11 @@ let args = yargs
     describe: 'App is run behind proxy (enable Express "trust proxy")',
     default: config.get('server.trustProxy')
   })
+  .options('max-hash-field-size', {
+    type: 'number',
+    describe: 'The max number of bytes for a hash field before you must click to view it',
+    default: config.get('server.maxHashFieldSize'),
+  })
   .options('nosave', {
     alias: 'ns',
     type: 'boolean',

--- a/bin/redis-commander.js
+++ b/bin/redis-commander.js
@@ -150,7 +150,7 @@ let args = yargs
   .options('max-hash-field-size', {
     type: 'number',
     describe: 'The max number of bytes for a hash field before you must click to view it',
-    default: config.get('server.maxHashFieldSize'),
+    default: config.get('ui.maxHashFieldSize'),
   })
   .options('nosave', {
     alias: 'ns',
@@ -205,6 +205,7 @@ let args = yargs
     config.noSave = value['nosave'];
     config.noLogData = value['no-log-data'];
     config.ui.foldingChar = value['folding-char'];
+    config.ui.maxHashFieldSize = value['max-hash-field-size'];
     config.redis.useScan = value['use-scan'];
     config.redis.readOnly = value['read-only'];
     config.redis.scanCount = value['scan-count'];

--- a/config/custom-environment-variables.json
+++ b/config/custom-environment-variables.json
@@ -21,6 +21,7 @@
     "urlPrefix": "URL_PREFIX",
     "trustProxy": "TRUST_PROXY",
     "clientMaxBodySize": "CLIENT_MAX_BODY_SIZE",
+    "maxHashFieldSize": "MAX_HASH_FIELD_SIZE",
     "httpAuth": {
       "username": "HTTP_USER",
       "password": "HTTP_PASSWORD",

--- a/config/custom-environment-variables.json
+++ b/config/custom-environment-variables.json
@@ -4,7 +4,8 @@
   "ui": {
     "foldingChar": "FOLDING_CHAR",
     "jsonViewAsDefault": "VIEW_JSON_DEFAULT",
-    "binaryAsHex": "BINARY_AS_HEX"
+    "binaryAsHex": "BINARY_AS_HEX",
+    "maxHashFieldSize": "MAX_HASH_FIELD_SIZE"
   },
   "redis": {
     "readOnly": "READ_ONLY",
@@ -21,7 +22,6 @@
     "urlPrefix": "URL_PREFIX",
     "trustProxy": "TRUST_PROXY",
     "clientMaxBodySize": "CLIENT_MAX_BODY_SIZE",
-    "maxHashFieldSize": "MAX_HASH_FIELD_SIZE",
     "httpAuth": {
       "username": "HTTP_USER",
       "password": "HTTP_PASSWORD",

--- a/config/default.json
+++ b/config/default.json
@@ -8,7 +8,8 @@
     "cliOpen": false,
     "foldingChar": ":",
     "jsonViewAsDefault": "none",
-    "binaryAsHex": true
+    "binaryAsHex": true,
+    "maxHashFieldSize": 0
   },
   "redis": {
     "readOnly": false,
@@ -26,7 +27,6 @@
     "urlPrefix": "",
     "trustProxy": false,
     "clientMaxBodySize": "100kb",
-    "maxHashFieldSize": 16384,
     "httpAuth": {
       "username": "",
       "password": "",

--- a/config/default.json
+++ b/config/default.json
@@ -26,6 +26,7 @@
     "urlPrefix": "",
     "trustProxy": false,
     "clientMaxBodySize": "100kb",
+    "maxHashFieldSize": 16384,
     "httpAuth": {
       "username": "",
       "password": "",

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -38,6 +38,7 @@ interface of Redis Commander.
 | ui.foldingChar | string | ':' | character to use for creation of a virtual hierarchical tree of all keys. e.g key 'top/sub/mykey' is divided into a folder 'top' containing the folder 'sub' with the key 'mykey' inside it. |
 | ui.jsonViewAsDefault | string list | 'none' | comma separated list of data types where valid json data should be displayed as JSON tree object instead of plain string. Default '' or 'none' displays no data as string, 'all' displays all data-types supported as JSON objects.<br>Example: "string,hash" only displays these two types as JSON if possible per default<br>Values supported: '', 'none', 'all', 'string', 'list', 'set', 'zset', 'hash'
 | ui.binaryAsHex | boolean | true | do not display binary data as string but in hexadecimal view |
+| ui.maxHashFieldSize | number | 0 | The max number of bytes for a hash field before you must click to view it. Defaults to 0, which is disabled
 
 ### 3. General Redis connection parameter
 
@@ -61,7 +62,6 @@ interface of Redis Commander.
 | server.urlPrefix | string | '/' | path prefix to run Redis Commander at, can be used if run behind a reverse proxy with different path set (e.g. /rc) |
 | server.trustProxy | boolean or string | false | should be set to true if run behind a reverse proxy and 'X-Forwarded-For' headers shall be trusted to get real client ip for logging, this parameter maps directly to the Express "trust proxy" setting (https://expressjs.com/de/guide/behind-proxies.html)|
 | server.clientMaxBodySize | number or string | '100kb' | number in bytes or a string with size and SI-unit, this parameter maps to the "limit" options of body-parser (https://github.com/expressjs/body-parser#limit) |
-| server.maxHashFieldSize | number | 16384 | The max number of bytes for a hash field before you must click to view it
 | server.auth | object |  | see section 4.1 Authentication  |
 
 #### 4.1 Authentication configuration for HTTP server

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -61,6 +61,7 @@ interface of Redis Commander.
 | server.urlPrefix | string | '/' | path prefix to run Redis Commander at, can be used if run behind a reverse proxy with different path set (e.g. /rc) |
 | server.trustProxy | boolean or string | false | should be set to true if run behind a reverse proxy and 'X-Forwarded-For' headers shall be trusted to get real client ip for logging, this parameter maps directly to the Express "trust proxy" setting (https://expressjs.com/de/guide/behind-proxies.html)|
 | server.clientMaxBodySize | number or string | '100kb' | number in bytes or a string with size and SI-unit, this parameter maps to the "limit" options of body-parser (https://github.com/expressjs/body-parser#limit) |
+| server.maxHashFieldSize | number | 16384 | The max number of bytes for a hash field before you must click to view it
 | server.auth | object |  | see section 4.1 Authentication  |
 
 #### 4.1 Authentication configuration for HTTP server

--- a/lib/routes/apiv1.js
+++ b/lib/routes/apiv1.js
@@ -97,6 +97,7 @@ module.exports = function (app) {
   routerV2.post('/xset/member/edit', middlewares.checkReadOnlyMode, notImplemented);
   routerV2.post('/xset/member/delete', middlewares.checkReadOnlyMode, postDeleteXSetMember);
 
+  routerV2.get('/hash/key/:connectionId/:key(*)', getHashField);
   routerV2.post('/hash/field', middlewares.checkReadOnlyMode, postAddHashField);
   routerV2.put('/hash/field', middlewares.checkReadOnlyMode, postEditHashField);
   routerV2.delete('/hash/field', middlewares.checkReadOnlyMode, postDeleteHashField);
@@ -433,20 +434,72 @@ function getKeyDetailsList (key, req, res, next) {
   });
 }
 
+// redis script to check the size of a hash field before retrieving it.
+const checkAndHGetScript = `
+local function checkAndGet(k, f)
+  local vlen=redis.call('hstrlen', k, f)
+  if (vlen > 0 and vlen < tonumber(ARGV[1])) then
+    return {vlen, redis.call('hget', k, f)}
+  else
+    return {vlen, nil}
+  end
+end
+return {(checkAndGet(KEYS[1], KEYS[2]))}
+`;
+
+function getKeyDetailsHashField(key, field, redisConnection, next) {
+  redisConnection.eval(checkAndHGetScript, 2, key, field, config.get('server.maxHashFieldSize'), function (err, data) {
+    if (err) {
+      console.error('getKeyDetailsHashField', err);
+      return next(err);
+    }
+    next(null, data[0]);  // should return [keyLen, value?]
+  });
+}
+
 function getKeyDetailsHash (key, res, next) {
   let redisConnection = res.locals.connection;
-  redisConnection.hgetall(key, function (err, fieldsAndValues) {
+  redisConnection.hkeys(key, function (err, fields) {
     if (err) {
-      console.error('getKeyDetailsHash', err);
+      console.error('getKeyDetailsHash:keys', err);
       return next(err);
     }
 
-    let details = {
-      key: key,
-      type: 'hash',
-      data: fieldsAndValues
-    };
-    sendWithTTL(details, key, redisConnection, res);
+    /**
+     * 
+     * @param {string[]} fields list of all field names
+     * @param {number} idx index of field name to work on
+     * @param {Map<string, string>} fieldsAndValues the map of fields to values
+     * @param {function} done final callback
+     */
+    function iterate(fields, idx, fieldsAndValues, done) {
+      if (idx >= fields.length) {
+        done(null, fieldsAndValues);
+      }
+      else {
+        getKeyDetailsHashField(key, fields[idx], redisConnection, function (err, result) {
+          if (err) {
+            return done(err);
+          }
+          // if the strlen > 0 and the result value is undefined then we want to return an explicit 
+          // null value so it can be interpretted as a deferred lookup value
+          fieldsAndValues[fields[idx]] = (result[0] < config.get("server.maxHashFieldSize"))? result[1] : null;
+          iterate(fields, idx + 1, fieldsAndValues, done);
+        });
+      }
+    }
+
+    iterate(fields, 0, {}, function (err, fieldsAndValues) {
+      if (err) {
+        return next(err);
+      }
+      let details = {
+        key: key,
+        type: 'hash',
+        data: fieldsAndValues
+      };
+      sendWithTTL(details, key, redisConnection, res);
+    });
   });
 }
 
@@ -733,6 +786,32 @@ function postDeleteXSetMember (req, res, next) {
 
 
 // hash
+function getHashField (req, res, next) {
+  let key = req.params.key;
+  let field = req.query.field;
+  if (!field) {
+    console.error('Missing "field" query parameter');
+    res.status(400).send({success: false, message: 'Missing "field" query parameter'});
+    return;
+  }
+  
+  let redisConnection = res.locals.connection;
+  console.log(sf('loading hash field "{0}" for key "{1}" from "{2}"', field, key, res.locals.connectionId));
+
+  redisConnection.hget(key, field, function (err, data) {
+    if (err) {
+      console.error('getHashField', err);
+      return next(err);
+    }
+
+    res.json({
+      key: key,
+      field: field,
+      data: data
+    });
+  });
+}
+
 function postAddHashField (req, res, next) {
   postEditHashField(req, res, next);
 }

--- a/lib/routes/apiv1.js
+++ b/lib/routes/apiv1.js
@@ -448,7 +448,7 @@ return {(checkAndGet(KEYS[1], KEYS[2]))}
 `;
 
 function getKeyDetailsHashField(key, field, redisConnection, next) {
-  redisConnection.eval(checkAndHGetScript, 2, key, field, config.get('server.maxHashFieldSize'), function (err, data) {
+  redisConnection.eval(checkAndHGetScript, 2, key, field, config.get('ui.maxHashFieldSize'), function (err, data) {
     if (err) {
       console.error('getKeyDetailsHashField', err);
       return next(err);
@@ -483,7 +483,7 @@ function getKeyDetailsHash (key, res, next) {
           }
           // if the strlen > 0 and the result value is undefined then we want to return an explicit 
           // null value so it can be interpretted as a deferred lookup value
-          fieldsAndValues[fields[idx]] = (result[0] < config.get("server.maxHashFieldSize"))? result[1] : null;
+          fieldsAndValues[fields[idx]] = (result[0] < config.get("ui.maxHashFieldSize"))? result[1] : null;
           iterate(fields, idx + 1, fieldsAndValues, done);
         });
       }

--- a/lib/routes/apiv1.js
+++ b/lib/routes/apiv1.js
@@ -434,35 +434,35 @@ function getKeyDetailsList (key, req, res, next) {
   });
 }
 
-// redis script to check the size of a hash field before retrieving it.
-const checkAndHGetScript = `
-local function checkAndGet(k, f)
-  local vlen=redis.call('hstrlen', k, f)
-  if (vlen > 0 and vlen < tonumber(ARGV[1])) then
-    return {vlen, redis.call('hget', k, f)}
-  else
-    return {vlen, nil}
-  end
-end
-return {(checkAndGet(KEYS[1], KEYS[2]))}
-`;
+function getKeyDetailsHash (key, res, next) {
+  let redisConnection = res.locals.connection;
+  let fieldRetrievalStrategy = (config.get("ui.maxHashFieldSize") > 0)? getSizeLimitedHashFields : getAllHashFields;
 
-function getKeyDetailsHashField(key, field, redisConnection, next) {
-  redisConnection.eval(checkAndHGetScript, 2, key, field, config.get('ui.maxHashFieldSize'), function (err, data) {
+  fieldRetrievalStrategy(redisConnection, key, res, function (err, fieldsAndValues) {
     if (err) {
-      console.error('getKeyDetailsHashField', err);
+      console.error('getKeyDetailsHash', err);
       return next(err);
     }
-    next(null, data[0]);  // should return [keyLen, value?]
+
+    let details = {
+      key: key,
+      type: 'hash',
+      data: fieldsAndValues
+    };
+    sendWithTTL(details, key, redisConnection, res);
   });
 }
 
-function getKeyDetailsHash (key, res, next) {
-  let redisConnection = res.locals.connection;
+function getAllHashFields(redisConnection, key, res, cb) {
+  redisConnection.hgetall(key, cb);
+}
+
+
+function getSizeLimitedHashFields(redisConnection, key, res, cb) {
   redisConnection.hkeys(key, function (err, fields) {
     if (err) {
       console.error('getKeyDetailsHash:keys', err);
-      return next(err);
+      return cb(err);
     }
 
     /**
@@ -489,19 +489,33 @@ function getKeyDetailsHash (key, res, next) {
       }
     }
 
-    iterate(fields, 0, {}, function (err, fieldsAndValues) {
-      if (err) {
-        return next(err);
-      }
-      let details = {
-        key: key,
-        type: 'hash',
-        data: fieldsAndValues
-      };
-      sendWithTTL(details, key, redisConnection, res);
-    });
+    iterate(fields, 0, {}, cb);
   });
 }
+
+// redis script to check the size of a hash field before retrieving it.
+const checkAndHGetScript = `
+local function checkAndGet(k, f)
+  local vlen=redis.call('hstrlen', k, f)
+  if (vlen > 0 and vlen < tonumber(ARGV[1])) then
+    return {vlen, redis.call('hget', k, f)}
+  else
+    return {vlen, nil}
+  end
+end
+return {(checkAndGet(KEYS[1], KEYS[2]))}
+`;
+
+function getKeyDetailsHashField(key, field, redisConnection, next) {
+  redisConnection.eval(checkAndHGetScript, 2, key, field, config.get('ui.maxHashFieldSize'), function (err, data) {
+    if (err) {
+      console.error('getKeyDetailsHashField', err);
+      return next(err);
+    }
+    next(null, data[0]);  // should return [keyLen, value?]
+  });
+}
+
 
 function getKeyDetailsReJSON (key, res, next) {
   let redisConnection = res.locals.connection;

--- a/lib/util.js
+++ b/lib/util.js
@@ -657,10 +657,11 @@ function validateConfig() {
   convertBoolean('server.trustProxy', true);
 
   // convert numbers and check if within valid range (e.g. ports)
-  ['ui.sidebarWidth', 'ui.cliHeight', 'redis.scanCount', 'server.port'].forEach(convertNumbers);
+  ['ui.sidebarWidth', 'ui.cliHeight', 'redis.scanCount', 'server.port', 'ui.maxHashFieldSize'].forEach(convertNumbers);
 
   validateNumbers('ui.sidebarWidth', true, 1, Number.MAX_VALUE);
   validateNumbers('ui.cliHeight', true, 1, Number.MAX_VALUE);
+  validateNumbers('ui.maxHashFieldSize', true, 0, Number.MAX_VALUE);
   validateNumbers('redis.scanCount', true, 0, Number.MAX_VALUE);
   validateNumbers('server.port', true, 1, 65535);
 

--- a/web/static/scripts/redisCommander.js
+++ b/web/static/scripts/redisCommander.js
@@ -782,6 +782,43 @@ function editHashField (connectionId, key, field, value) {
   enableJsonValidationCheck(value, '#hashFieldIsJson');
 }
 
+function showHashField (connectionId, key, field) {
+  $.get('apiv2/hash/key/' + encodeURIComponent(connectionId) + "/" + encodeURIComponent(key) + "?field=" + encodeURIComponent(field))
+      .done(processData)
+      .fail(errorHandler)
+
+  function processData (keyData, status) {
+    if (status !== 'success') {
+      return alert("Could not load key data");
+    }
+    if (typeof keyData === 'string') keyData = JSON.parse(keyData);
+    
+    var deferredRow = $('tr[data-deferred-field="' + field + '"');
+    if (deferredRow) {
+      // inject the data into the view
+      deferredRow.find('td.text-renderer').text(keyData.data);
+
+      // regenerate the json view
+      dataUIFuncs.createJSONViews(deferredRow.find('td.json-renderer'));
+
+      // remove the deferred attribute so the value is editable
+      deferredRow.removeAttr('data-deferred-field');
+    }
+  }
+
+  function errorHandler(error) {
+    if (error.responseJSON) {
+      if (error.responseJSON.message) {
+        $('#body').html('<h5>Got ERROR: ' + error.responseJSON.message + '</h5>');
+      }
+      else {
+        $('#body').html('<h5>Network ERROR calling server...</h5>');
+      }
+      if (error.responseJSON.connectionClosed) setRootConnectionNetworkError(true, getKeyTree().get_selected(true)[0]);
+    }
+  }
+}
+
 /** check if given string value is valid json and, if so enable validation
  *  for given field if this is an json object or array. Do not automatically
  *  enable validation on numbers or quted strings. May be coincidence that this is json...

--- a/web/static/templates/editHash.ejs
+++ b/web/static/templates/editHash.ejs
@@ -21,14 +21,24 @@
     </thead>
     <tbody>
     <% for(var field in data) { %>
-      <tr>
-          <td><%= field %></td>
+      <tr
+        <% if (data[field] === null) { %>
+          data-deferred-field="<%= field %>"
+        <% } %>
+        >
+        <td><%= field %></td>
         <% console.log(field);%>
         <% console.log(data[field]);%>
-          <td id="plain_<%= field %>" class="text-renderer"><%= data[field] %></td>
-          <td id="jqtree_<%= field %>" class="json-renderer" style="display:none;">loading ...</td>
-        </tr>
-      <% } %>
+        <td id="plain_<%= field %>" class="text-renderer">
+          <% if (data[field] !== null) { %>
+            <%= data[field] %>
+          <% } else { %>
+            <a data-deferred-field="<%= field %>">This is a large field. Click here to view.</a>
+          <% } %>
+        </td>
+        <td id="jqtree_<%= field %>" class="json-renderer" style="display:none;">loading ...</td>
+      </tr>
+    <% } %>
     </tbody>
   </table>
 </div>
@@ -39,11 +49,22 @@
         var connectionId = "<%= connectionId %>";
         var key = "<%= key %>";
         var row = event.currentTarget;
+        if ('deferredField' in row.dataset) {
+          console.log('Deferred fields are not editable')
+          return;
+        }
         var field = row.children[0].innerHTML.toString();
         var value = row.children[1].innerHTML.toString();
         editHashField(connectionId, key, field, value);
       });
     }
+
+    $('.table tbody tr a[data-deferred-field]').click(function (event) {
+      var connectionId = "<%= connectionId %>";
+      var key = "<%= key %>";
+      var field = event.target.dataset.deferredField;
+      showHashField(connectionId, key, field);
+    });
 
     dataUIFuncs.createJSONViews('td[class="json-renderer"]');
   });


### PR DESCRIPTION
As discussed in https://github.com/joeferner/redis-commander/issues/409 this PR adds a maxHashFieldSize config to limit the size of hash fields retrieved from redis. The UI will show any large hash fields as a deferred 'click to view' request that will pull the data manually.

I may have set the default value on the new config too low (16kb) but I figured any request larger than 16kb is probably going to be too large to even show in the viewer anyways, so there's no sense in pulling data unless the user wants it.

Let me know if I've gotten everything, or any other suggestions. Thanks!