### PR TITLE
Fixed redis-commander.js won't respect flag sentinel-password

### DIFF
--- a/bin/redis-commander.js
+++ b/bin/redis-commander.js
@@ -389,6 +389,7 @@ function createConnectionObjectFromArgs(args) {
       connObj.host = args['redis-host'] || 'localhost';
       connObj.port = args['redis-port'] || 6379;
       connObj.port = parseInt(connObj.port);
+      connObj.sentinelPassword = args['sentinel-password'] || '';
       if (args['sentinels']) {
         connObj.sentinels = myUtils.parseRedisSentinel('--sentinels', args['sentinels']);
         connObj.sentinelName = args['sentinel-name'] || config.get('redis.defaultSentinelGroup');


### PR DESCRIPTION
I found that I cannot configure redis-commander to use sentinel password so I created this fix.