### PR TITLE
Add support for multi platform images

### DIFF
--- a/.github/workflows/docker-publish.yml
+++ b/.github/workflows/docker-publish.yml
@@ -6,6 +6,11 @@ on:
     branches:
       - master
 
+  workflow_dispatch:
+  pull_request:
+    branches: 
+      - master
+
 env:
   # TODO: Change variable to your image's name.
   IMAGE_NAME: redis-commander

--- a/.github/workflows/docker-publish.yml
+++ b/.github/workflows/docker-publish.yml
@@ -39,6 +39,7 @@ jobs:
       - name: build and push
         uses: docker/build-push-action@v1.1.1
         with:
+          platforms: linux/arm/v6,linux/arm/v7,linux/arm64/v8,linux/386,linux/amd64
           push: true
           tag: milkyjoe93/redis-commander:latest
       

--- a/.github/workflows/docker-publish.yml
+++ b/.github/workflows/docker-publish.yml
@@ -21,22 +21,25 @@ jobs:
     runs-on: ubuntu-latest
     
     steps:
-      - name: checkout
+      - name: Checkout
         uses: actions/checkout@v2.3.3
       
-      - name: install buildx
+      - name: Set up QEMU
+        uses: docker/setup-qemu-action@v1
+      
+      - name: Install Buildx
         id: buildx
         uses: docker/setup-buildx-action@v1.0.2
         with: 
           version: latest
           
-      - name: docker login
+      - name: Docker login
         uses: docker/login-action@v1.4.1
         with: 
           username: "${{ secrets.DOCKER_USERNAME }}"
           password: "${{ secrets.DOCKER_PASSWORD }}"
         
-      - name: build and push
+      - name: Docker build and push
         uses: docker/build-push-action@v2
         with:
           context: .

--- a/.github/workflows/docker-publish.yml
+++ b/.github/workflows/docker-publish.yml
@@ -45,7 +45,7 @@ jobs:
           context: .
           platforms: linux/arm/v6,linux/arm/v7,linux/arm64/v8,linux/386,linux/amd64
           push: true
-          tags: milkyjoe93/redis-commander:latest
+          tags: "${{ secrets.DOCKER_REPO }}/redis-commander:latest"
       
       - name: Image digest
         run: echo ${{ steps.docker_build.outputs.digest }}

--- a/.github/workflows/docker-publish.yml
+++ b/.github/workflows/docker-publish.yml
@@ -37,8 +37,9 @@ jobs:
           password: "${{ secrets.DOCKER_PASSWORD }}"
         
       - name: build and push
-        uses: docker/build-push-action@v1.1.1
+        uses: docker/build-push-action@v2
         with:
+          context: .
           platforms: linux/arm/v6,linux/arm/v7,linux/arm64/v8,linux/386,linux/amd64
           push: true
           tag: milkyjoe93/redis-commander:latest

--- a/.github/workflows/docker-publish.yml
+++ b/.github/workflows/docker-publish.yml
@@ -42,7 +42,7 @@ jobs:
           context: .
           platforms: linux/arm/v6,linux/arm/v7,linux/arm64/v8,linux/386,linux/amd64
           push: true
-          tag: milkyjoe93/redis-commander:latest
+          tags: milkyjoe93/redis-commander:latest
       
       - name: Image digest
         run: echo ${{ steps.docker_build.outputs.digest }}

--- a/.github/workflows/docker-publish.yml
+++ b/.github/workflows/docker-publish.yml
@@ -23,6 +23,17 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@v2.3.3
+        
+      - name: Github Tag
+        id: tag
+        # You may pin to the exact commit or the version.
+        # uses: anothrNick/github-tag-action@18284c78f6ac68868d5341f57c4f971fb5b7605c
+        uses: mathieudutour/github-tag-action@v5.3
+        with:
+          github_token: ${{secrets.GITHUB_TOKEN}}
+        
+      - name: Echo tag
+        run: echo ${{steps.tag.outputs.new_tag}}
       
       - name: Set up QEMU
         uses: docker/setup-qemu-action@v1
@@ -36,8 +47,9 @@ jobs:
       - name: Docker login
         uses: docker/login-action@v1.4.1
         with: 
-          username: "${{ secrets.DOCKER_USERNAME }}"
-          password: "${{ secrets.DOCKER_PASSWORD }}"
+          registry: "${{secrets.DOCKER_REGISTRY}}"
+          username: "${{secrets.DOCKER_USERNAME}}"
+          password: "${{secrets.DOCKER_PASSWORD}}"
         
       - name: Docker build and push
         uses: docker/build-push-action@v2
@@ -45,8 +57,10 @@ jobs:
           context: .
           platforms: linux/arm/v6,linux/arm/v7,linux/arm64/v8,linux/386,linux/amd64
           push: true
-          tags: "${{ secrets.DOCKER_REPO }}/redis-commander:latest"
+          tags: |
+            "${{secrets.DOCKER_REGISTRY}}/${{secrets.DOCKER_REPO}}/redis-commander:latest"
+            "${{secrets.DOCKER_REGISTRY}}/${{secrets.DOCKER_REPO}}/redis-commander:${{steps.tag.outputs.new_tag}}"
       
       - name: Image digest
-        run: echo ${{ steps.docker_build.outputs.digest }}
+        run: echo ${{steps.docker_build.outputs.digest}}
         

--- a/.github/workflows/docker-publish.yml
+++ b/.github/workflows/docker-publish.yml
@@ -1,0 +1,42 @@
+name: Docker
+
+on:
+  push:
+    # Publish `master` as Docker `latest` image.
+    branches:
+      - master
+
+env:
+  # TODO: Change variable to your image's name.
+  IMAGE_NAME: redis-commander
+
+jobs:
+  build:
+    name: Build image and push
+    runs-on: ubuntu-latest
+    
+    steps:
+      - name: checkout
+        uses: actions/checkout@v2.3.3
+      
+      - name: install buildx
+        id: buildx
+        uses: docker/setup-buildx-action@v1.0.2
+        with: 
+          version: latest
+          
+      - name: docker login
+        uses: docker/login-action@v1.4.1
+        with: 
+          username: "${{ secrets.DOCKER_USERNAME }}"
+          password: "${{ secrets.DOCKER_PASSWORD }}"
+        
+      - name: build and push
+        uses: docker/build-push-action@v1.1.1
+        with:
+          push: true
+          tag: milkyjoe93/redis-commander:latest
+      
+      - name: Image digest
+        run: echo ${{ steps.docker_build.outputs.digest }}
+        


### PR DESCRIPTION
Hi,

This is kind of in relation to #345 

Been wanting to use this image to have a web UI to manage my redis install on a raspberry pi, however on docker hub it states the latest tag only support Linux/amd64 despite the fact that the alpine image this is based on supports more platforms.

I don't know what you guys use for publishing to docker hub currently, but I've had a look at GitHub actions and built a docker buildx action which pushes x86, x64 and arm images to docker hub. For an example please feel free to look at [my docker hub](https://hub.docker.com/repository/docker/milkyjoe93/redis-commander/tags?page=1)

This action will automatically build on each commit to master but also support manual triggers.

Hope this is useful
Cameron