### PR TITLE
Fix a regression

### DIFF
--- a/lib/routes/apiv1.js
+++ b/lib/routes/apiv1.js
@@ -576,7 +576,7 @@ function getKeyDetailsZSet (key, req, res, next) {
     });
     redisConnection.zcount(key, "-inf", "+inf", function (errCount, length) {
       if (errCount) {
-        console.error('getKeyDetailsZSet - zcount', err);
+        console.error('getKeyDetailsZSet - zcount', errCount);
         length = 0;
         //return next(err);
       }
@@ -635,8 +635,8 @@ function getKeyDetailsXSet (key, req, res, next) {
     });
 
     redisConnection.xlen(key, function (errLen, length) {
-      if (errCount) {
-        console.error('getKeyDetailsXSet - xlen', err);
+      if (errLen) {
+        console.error('getKeyDetailsXSet - xlen', errLen);
         length = 0;
         //return next(err);
       }


### PR DESCRIPTION
Fix a regression due to commit a85acb75c9daca7f205b9c53c72e0bb0c84e76ee (remove shadowed variable declarations)

```
loading key "messages" from "R:redis:6379:4"
/redis-commander/node_modules/standard-as-callback/built/index.js:6
        throw e;
        ^

ReferenceError: errCount is not defined
    at /redis-commander/lib/routes/apiv1.js:638:7
    at tryCatcher (/redis-commander/node_modules/standard-as-callback/built/utils.js:11:23)
    at /redis-commander/node_modules/standard-as-callback/built/index.js:19:49
    at processTicksAndRejections (internal/process/task_queues.js:94:5)
```