### PR TITLE
Fix ReJSON visualization / editing

### DIFF
--- a/lib/routes/apiv1.js
+++ b/lib/routes/apiv1.js
@@ -1128,7 +1128,7 @@ function saveKey (req, res, next) {
           case 'hash':
               return editHashField(key, field, value, res, next);
           case 'ReJSON-RL':
-              return editReJSONData(key, value, res, next);
+              return editReJSONData(key, value, req, res, next);
           default:
               return next(new Error("Unhandled type " + type));
       }
@@ -1231,6 +1231,18 @@ function posKeyDetailsString (key, value, req, res, next) {
   redisConnection.set(key, value, function (err) {
     if (err) {
       console.error('posKeyDetailsString', err);
+      return next(err);
+    }
+    res.send('OK');
+  });
+}
+
+function editReJSONData (key, value, req, res, next) {
+  if (!req.app.locals.noLogData) console.log('new value for key: ', value);
+  let redisConnection = res.locals.connection;
+  redisConnection.call('JSON.SET', key, '.', value, function (err) {
+    if (err) {
+      console.error('editReJSONData', err);
       return next(err);
     }
     res.send('OK');

--- a/web/static/scripts/redisCommander.js
+++ b/web/static/scripts/redisCommander.js
@@ -294,7 +294,7 @@ function loadKey (connectionId, key, index) {
         selectTreeNodeBinary(keyData);
         break;
       case 'ReJSON-RL':
-        selectTreeNodeReJSON(keyData);
+        selectTreeNodeString(keyData);
         break;
       case 'none':
         selectTreeNodeBranch(keyData);

--- a/web/static/templates/editString.ejs
+++ b/web/static/templates/editString.ejs
@@ -10,7 +10,7 @@
 <div id="itemData">
   <label>Key: <b><%= key %></b></label>
   <label>TTL: <b><%= ttl %></b></label>
-  <label>Type: <b>String</b></label>
+  <label>Type: <b><%= type %></b></label>
   <form id="editStringForm" action="apiv1/key/<%= connectionId %>/<%= key %>" method="POST" class="form-vertical">
     <div id="jqtree_string_div" class="json-renderer" style="display: none;">loading ...</div>
     <span id="stringValueBox" class="text-renderer">


### PR DESCRIPTION
at the moment is only possible to see rejson data as a string, using default string visualization template is much better because json can be seen as a tree and there is also the form ready for editing the data.
`editReJSONData` method was not present and failing so I added it.
At the moment the visualization is switched to use `selectTreeNodeString` for better visualization, or it is possible to duplicate `selectTreeNodeString` and the template into `selectTreeNodeReJSON`