### PR TITLE
Feature: Allow username to be specified for connections

### DIFF
--- a/README.md
+++ b/README.md
@@ -40,6 +40,7 @@ Options:
   --redis-port                         The port to find redis on.                  [string]
   --redis-host                         The host to find redis on.                  [string]
   --redis-socket                       The unix-socket to find redis on.           [string]
+  --redis-username                     The redis username.                         [string]
   --redis-password                     The redis password.                         [string]
   --redis-db                           The redis database.                         [string]
   --redis-label                        The label to display for the connection.    [string]
@@ -49,6 +50,7 @@ Options:
   --sentinel-host                      The host to find redis sentinel on.         [string]
   --sentinels                          Comma separated list of sentinels with host:port. [string]
   --sentinel-name                      The redis sentinel group name to use.       [string]  [default: mymaster]
+  --sentinel-username                  The username for sentinel instance.         [string]
   --sentinel-password                  The password for sentinel instance.         [string]
   --http-auth-username, --http-u       The http authorisation username.            [string]
   --http-auth-password, --http-p       The http authorisation password.            [string]
@@ -155,6 +157,7 @@ REDIS_PORT
 REDIS_HOST
 REDIS_SOCKET
 REDIS_TLS
+REDIS_USERNAME
 REDIS_PASSWORD
 REDIS_PASSWORD_FILE
 REDIS_DB
@@ -163,6 +166,7 @@ REDIS_OPTIONAL
 SENTINEL_PORT
 SENTINEL_HOST
 SENTINEL_NAME
+SENTINEL_USERNAME
 SENTINEL_PASSWORD
 SENTINEL_PASSWORD_FILE
 SENTINELS

--- a/bin/redis-commander.js
+++ b/bin/redis-commander.js
@@ -31,6 +31,10 @@ let args = yargs
     type: 'string',
     describe: 'The unix-socket to find redis on.'
   })
+  .options('redis-username', {
+    type: 'string',
+    describe: 'The redis username.'
+  })
   .options('redis-password', {
     type: 'string',
     describe: 'The redis password.'
@@ -59,6 +63,10 @@ let args = yargs
   .options('sentinel-name', {
     type: 'string',
     describe: 'The sentinel group name to use.'
+  })
+  .options('sentinel-username', {
+    type: 'string',
+    describe: 'The sentinel username to use.'
   })
   .options('sentinel-password', {
     type: 'string',
@@ -371,12 +379,13 @@ function createConnectionObjectFromArgs(argList) {
   // now create connection object if enough params are set
   let connObj = null;
   if (argList['sentinel-host'] || argList['sentinels'] || argList['redis-host'] || argList['redis-port'] || argList['redis-socket']
-    || argList['redis-password'] || argList['redis-db']) {
+    || argList['redis-username'] || argList['redis-password'] || argList['redis-db']) {
 
     let db = parseInt(argList['redis-db']);
     connObj = {
       label: config.get('redis.defaultLabel'),
       dbIndex: Number.isNaN(db) ? 0 : db,
+      username: argList['redis-username'] || null,
       password: argList['redis-password'] || '',
       connectionName: config.get('redis.connectionName'),
       optional: argList['redis-optional']
@@ -389,6 +398,7 @@ function createConnectionObjectFromArgs(argList) {
       connObj.host = argList['redis-host'] || 'localhost';
       connObj.port = argList['redis-port'] || 6379;
       connObj.port = parseInt(connObj.port);
+      connObj.sentinelUsername = argList['sentinel-username'] || null;
       connObj.sentinelPassword = argList['sentinel-password'] || '';
       if (argList['sentinels']) {
         connObj.sentinels = myUtils.parseRedisSentinel('--sentinels', argList['sentinels']);

--- a/docker/entrypoint.sh
+++ b/docker/entrypoint.sh
@@ -226,6 +226,10 @@ if [ -n "$REDIS_TLS" ] && parse_boolean "$REDIS_TLS"; then
     set -- "$@" "--redis-tls"
 fi
 
+if [ -n "$REDIS_USERNAME" ]; then
+    set -- "$@" "--redis-username" "$REDIS_USERNAME"
+fi
+
 if [ -n "$REDIS_PASSWORD" ]; then
     set -- "$@" "--redis-password" "$REDIS_PASSWORD"
 fi
@@ -252,6 +256,10 @@ fi
 
 if [ -n "$SENTINEL_NAME" ]; then
     set -- "$@" "--sentinel-name" "$SENTINEL_NAME"
+fi
+
+if [ -n "$SENTINEL_USERNAME" ]; then
+    set -- "$@" "--sentinel-username" "$SENTINEL_USERNAME"
 fi
 
 if [ -n "$SENTINEL_PASSWORD" ]; then

--- a/lib/util.js
+++ b/lib/util.js
@@ -288,6 +288,7 @@ function createRedisClient(clientConfig, callback) {
   let redisOpts = {
     //showFriendlyErrorStack: true,
     db: clientConfig.dbIndex,
+    username: clientConfig.username,
     password: clientConfig.password,
     connectionName: clientConfig.connectionName || c.get('redis.connectionName'),
     retryStrategy: function (times) {
@@ -313,6 +314,7 @@ function createRedisClient(clientConfig, callback) {
     Object.assign(redisOpts, {
       sentinels: clientConfig.sentinels,
       name: getRedisSentinelGroupName(clientConfig.sentinelName),
+      sentinelUsername: clientConfig.sentinelUsername || null,
       sentinelPassword: clientConfig.sentinelPassword || null
     });
     conId = `S:${redisOpts.sentinels[0].host}:${redisOpts.sentinels[0].port}:${redisOpts.name}-${redisOpts.db}`;


### PR DESCRIPTION
For both Redis and Sentinel connections, there was no way to specify a password along with the username. All connections to redis could only go through the default account. In some setup configurations, the default account may be disabled in favor of using individual usernames and limiting access to what each user may have.

In this commit, the username parameter (in the config), along with CLI parameters `--redis-username` and `--sentinel-username` have been added to support this use case. The docker entrypoint.sh has also been modified to accomodate the new parameters. The hosts environment variable has been left unchanged due to it's complexity and strict format. I felt that it would be a breaking change to modify it in a way that makes sense. It has been left as is for backwards compatibility.