### PR TITLE
Remove log spamming message

### DIFF
--- a/bin/redis-commander.js
+++ b/bin/redis-commander.js
@@ -447,7 +447,6 @@ function startAllConnections() {
           }
           else {
             let count = res[0], curKeys = res[1];
-            console.log("scanning: " + count + ": " + curKeys.length);
             keys = keys.concat(curKeys);
             if (Number(count) === 0) {
               if (typeof cb === 'function') cb(null, keys);


### PR DESCRIPTION
The "scanning" message burst from time to time, spamming log with thousand log lines in short period of time (under 30s).