### PR TITLE
support helm-chart using config file

### DIFF
--- a/k8s/helm-chart/example-manifest.yaml
+++ b/k8s/helm-chart/example-manifest.yaml
@@ -1,0 +1,101 @@
+apiVersion: helm.toolkit.fluxcd.io/v2beta1
+kind: HelmRelease
+metadata:
+  name: redis-commander
+spec:
+  releaseName: redis-commander
+  values:
+    image:
+      repository: ghcr.io/joeferner/redis-commander
+      tag: latest
+    connections:
+      local_production_json: >-
+        {
+          "noSave": false,
+          "noLogData": false,
+          "ui": {
+            "sidebarWidth": 250,
+            "locked": false,
+            "cliHeight": 320,
+            "cliOpen": false,
+            "foldingChar": ":",
+            "jsonViewAsDefault": "none",
+            "binaryAsHex": true,
+            "maxHashFieldSize": 0
+          },
+          "redis": {
+            "readOnly": false,
+            "flushOnImport": false,
+            "useScan": true,
+            "scanCount": 100,
+            "rootPattern": "*",
+            "connectionName": "redis-commander",
+            "defaultLabel": "local",
+            "defaultSentinelGroup": "mymaster"
+          },
+          "server": {
+            "address": "0.0.0.0",
+            "port": 8081,
+            "urlPrefix": "",
+            "signinPath": "signin",
+            "httpAuthHeaderName": "Authorization",
+            "trustProxy": false,
+            "clientMaxBodySize": "100kb",
+            "httpAuth": {
+              "username": "",
+              "password": "",
+              "passwordHash": "",
+              "comment": "to enable http auth set username and either password or passwordHash",
+              "jwtSecret": ""
+            }
+          },
+          "sso": {
+            "enabled": false,
+            "jwtSharedSecret": "",
+            "jwtAlgorithms": ["HS256", "HS384", "HS512"],
+            "allowedIssuer": "",
+            "audience": "",
+            "subject": ""
+          },
+          "connections": [
+            {
+              "label": "redis-sentinel-service-x",
+              "sentinels": "19.94.12.11:26379",
+              "sentinelName": "mymaster",
+              "dbIndex": 0
+            },
+            {
+              "label": "redis-sentinel-service-y",
+              "sentinels": "19.94.12.11:26379",
+              "sentinelName": "mymaster",
+              "dbIndex": 0
+            },
+            {
+              "label": "redis-server-service-xz",
+              "host": "19.94.12.11",
+              "port": "6379",
+              "dbIndex": 0
+            },
+            {
+              "label": "redis-server-service-yz",
+              "host": "19.94.12.11",
+              "port": "6379",
+              "dbIndex": 0
+            }
+          ]
+        }
+    volumeMounts:
+      - name: local-production
+        mountPath: /redis-commander/config
+    volumes:
+        - name: local-production
+          configMap:
+            name: redis-commander-configmap
+  rollback:
+    disableWait: true
+    cleanupOnFail: true
+  upgrade:
+    cleanupOnFail: true
+    remediation:
+      retries: 3
+  maxHistory: 5

--- a/k8s/helm-chart/redis-commander/Chart.yaml
+++ b/k8s/helm-chart/redis-commander/Chart.yaml
@@ -11,7 +11,7 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 0.3.0
+version: 0.3.1
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to

--- a/k8s/helm-chart/redis-commander/templates/configmap.yaml
+++ b/k8s/helm-chart/redis-commander/templates/configmap.yaml
@@ -1,0 +1,6 @@
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: {{ .Release.Name }}-configmap
+data:
+  local-production.json: {{ .Values.connections.local_production_json | toJson }}

--- a/k8s/helm-chart/redis-commander/templates/deployment.yaml
+++ b/k8s/helm-chart/redis-commander/templates/deployment.yaml
@@ -76,6 +76,10 @@ spec:
           {{- end }}
           - name: K8S_SIGTERM
             value: "1"
+          {{- with .Values.volumeMounts }}
+          volumeMounts:
+            {{- toYaml . | default "" | nindent 12 }}
+          {{- end }}
           livenessProbe:
             httpGet:
               path: /favicon.png
@@ -84,6 +88,10 @@ spec:
             timeoutSeconds: 5
           resources:
             {{- toYaml .Values.resources | nindent 12 }}
+      {{- with .Values.volumes }}
+      volumes:
+        {{- toYaml . | default "" | nindent 8 }}
+      {{- end }}
       {{- with .Values.nodeSelector }}
       nodeSelector:
         {{- toYaml . | nindent 8 }}

--- a/k8s/helm-chart/redis-commander/values.schema.json
+++ b/k8s/helm-chart/redis-commander/values.schema.json
@@ -186,6 +186,15 @@
         },
         "tolerations": {
             "type": "array"
+        },
+        "connections": {
+        "type": "object"
+        },
+        "volumeMounts": {
+        "type": "array"
+        },
+        "volumes": {
+        "type": "array"
         }
     }
 }

--- a/k8s/helm-chart/redis-commander/values.yaml
+++ b/k8s/helm-chart/redis-commander/values.yaml
@@ -143,3 +143,9 @@ nodeSelector: {}
 tolerations: []
 
 affinity: {}
+
+connections: {}
+
+volumeMounts: []
+
+volumes: []


### PR DESCRIPTION
add new feature in helm-charts redis-commander

1. Add example manifest HelmRelease 
2. Enable multiple connection redis-sentinel and redis-server via config file 
3. Add new variable connections, volumeMounts and volumes for generating config file local-production.json via configmap

Thanks.