### PR TITLE
Fix doc for nosave env variable

### DIFF
--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -21,7 +21,7 @@ All top-level configuration data are
 
 | Name        | Type    | Default | Cli           | Environment-Var | Description |
 |-------------|---------|---------|---------------|-----------------|---|
-| noSave      | boolean | false   | --nosave      | NO_SAVE         | do not persist changes in active connection list  |
+| noSave      | boolean | false   | --nosave      | NOSAVE          | do not persist changes in active connection list  |
 | noLogData   | boolean | false   | --no-log-data | NO_LOG_DATA     | do not log values of redis keys to console |
 | ui          | object  |         |               |                 | see section 2. User interface parameter|
 | redis       | object  |         |               |                 | see section 3. General Redis connection parameter |


### PR DESCRIPTION
Tried to run with `NO_SAVE=true` but start up log showed `No Save: false`. Used `NOSAVE` as listed in https://github.com/joeferner/redis-commander?tab=readme-ov-file#environment-variables and worked.