### PR TITLE
default values of k8s helm chart

### DIFF
--- a/k8s/helm-chart/redis-commander/values.yaml
+++ b/k8s/helm-chart/redis-commander/values.yaml
@@ -167,7 +167,8 @@ affinity: {}
 #  file from a configmap to preconfigure more complex configuration examples with connection data too
 #  without the need to set all parameter via environment variables (where available).
 #  For a working example see file "example-manifest.yaml"
-connections: {}
+connections:
+  local_production_json: ""
 
 # -- optional list of volumes to mount into the docker deployment. This can either be a local storage volume
 #  or a configmap to mount data as file. Each list item needs a "name" and a "mountPath". Setting this will most time


### PR DESCRIPTION
Hello. I've got the same error.

https://github.com/joeferner/redis-commander/issues/543

"$ helm install redis-commander -f ./values.yaml . -n redis
And get error:
Error: INSTALLATION FAILED: unable to build kubernetes objects from release manifest: error validating "": error validating data: unknown object type "nil" in ConfigMap.data.local-production.json"

It happens here because connections does not have any local_production_json value

configmap.yaml:
local-production.json: {{ .Values.connections.local_production_json | toJson }}

Please, add this fix. It works for me.

connections:
  local_production_json: ""