### PR TITLE
Helm Release job

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,26 @@
+name: Release Charts
+
+on:
+  workflow_dispatch:
+
+jobs:
+  release:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+
+      - name: Configure Git
+        run: |
+          git config user.name "$GITHUB_ACTOR"
+          git config user.email "$GITHUB_ACTOR@users.noreply.github.com"
+
+      - name: Run chart-releaser
+        uses: helm/chart-releaser-action@v1.6.0
+        with:
+          config: cr.yaml
+          charts_dir: ./k8s/helm-charts
+        env:
+          CR_TOKEN: "${{ secrets.GITHUB_TOKEN }}"

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -23,6 +23,6 @@ jobs:
         uses: helm/chart-releaser-action@v1.6.0
         with:
           config: cr.yaml
-          charts_dir: k8s/helm-charts
+          charts_dir: k8s/helm-chart
         env:
           CR_TOKEN: "${{ secrets.GITHUB_TOKEN }}"

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -23,6 +23,6 @@ jobs:
         uses: helm/chart-releaser-action@v1.6.0
         with:
           config: cr.yaml
-          charts_dir: ./k8s/helm-charts
+          charts_dir: k8s/helm-charts
         env:
           CR_TOKEN: "${{ secrets.GITHUB_TOKEN }}"

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,7 +1,9 @@
 name: Release Charts
 
 on:
-  workflow_dispatch:
+  push:
+    branches:
+      - master
 
 jobs:
   release:

--- a/cr.yaml
+++ b/cr.yaml
@@ -1,0 +1,5 @@
+sign: false
+
+# Enable automatic generation of release notes using GitHubs release notes generator.
+# see: https://docs.github.com/en/repositories/releasing-projects-on-github/automatically-generated-release-notes
+generate-release-notes: true

--- a/k8s/helm-chart/redis-commander/Chart.yaml
+++ b/k8s/helm-chart/redis-commander/Chart.yaml
@@ -11,7 +11,7 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 0.6.0
+version: 0.6.1
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to

--- a/k8s/helm-chart/release_charts
+++ b/k8s/helm-chart/release_charts
@@ -1,7 +1,0 @@
-#!/bin/bash
-# author Abdennour Toumi (https://github.com/abdennour)
-
-dir="$( cd "$( dirname "${BASH_SOURCE[0]}" )" >/dev/null 2>&1 && pwd )";
-cd "${dir}" || exit
-helm package redis-commander
-helm repo index .


### PR DESCRIPTION
This adds a workflow, using chart releaser, to release the helm chart to the gh-pages branch. So others can us it as a repo.

```
helm repo add redis-commander https://joeferner.github.io/redis-commander/
helm install redis-commander/redis-commander
```