### PR TITLE
fix(docker): upgrade Alpine to 3.22 to address CVE-2025-6965 in sqlite-libs

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM alpine:3.21
+FROM alpine:3.22
 
 WORKDIR /redis-commander
 


### PR DESCRIPTION
Upgraded base image from Alpine 3.21 to 3.22 to avoid critical memory corruption vulnerability (CVE-2025-6965) in sqlite-libs@3.48.0-r2.

dependency tree via nodejs -> sqlite-libs.