### PR TITLE
Add null checks on connection commands array

### DIFF
--- a/lib/connections.js
+++ b/lib/connections.js
@@ -308,8 +308,10 @@ class ConnectionWrapper {
         //   redisConnection.options.port);
         const extraROCmds = require('config').get('redis.extraAllowedReadOnlyCommands');
         redisConnection.options.commandList = {
-          all: p[0].value.map((item) => (item[0].toLowerCase())),
-          ro: p[0].value.filter((item) => (item[2].indexOf('readonly') >= 0 || extraROCmds.indexOf(item[0]) >= 0))
+          all: p[0].value.filter(item => item && Array.isArray(item) && item.length > 0)
+                         .map((item) => (item[0].toLowerCase())),
+          ro: p[0].value.filter((item) => item && Array.isArray(item) && item.length > 2 &&
+                                (item[2].indexOf('readonly') >= 0 || extraROCmds.indexOf(item[0]) >= 0))
                         .map((item) => (item[0].toLowerCase()))
         };
       }


### PR DESCRIPTION
This PR aims to fix the issue of using a Microsoft Garnet server instance with redis commander. The list of commands for this instance contains some null values.
Closes #598 