### PR TITLE
chore: add start period to healtcheck

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -36,7 +36,7 @@ RUN  apk update \
 
 USER 10000
 
-HEALTHCHECK --interval=1m --timeout=2s CMD ["/redis-commander/bin/healthcheck.js"]
+HEALTHCHECK --interval=1m --timeout=2s --start-period=1s CMD ["/redis-commander/bin/healthcheck.js"]
 
 ENTRYPOINT ["/usr/bin/dumb-init", "--"]
 CMD ["/redis-commander/docker/entrypoint.sh"]


### PR DESCRIPTION
This improved the time it will take when docker compose see the service as healty.
