### PR TITLE
chore(release): bump version to 0.9.2

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## Next Version
 
+## Version 0.9.2
+#### Bugfixes
+* fix docker-compose.yml port mapping to expose Redis Commander on port 666 instead of 8081 to avoid common port conflicts
+
 ## Version 0.9.1
 #### Bugfixes
 * fix bug with docker variables used by REPLACE_CONFIG_ENV containing some special characters

--- a/package.json
+++ b/package.json
@@ -8,7 +8,7 @@
     "Stefan Seide <account-github@seide.st"
   ],
   "name": "redis-commander",
-  "version": "0.9.1",
+  "version": "0.9.2",
   "description": "Redis web-based management tool written in node.js",
   "license": "MIT",
   "repository": {


### PR DESCRIPTION
Closed - will work on personal fork only.